### PR TITLE
Fix dependencies for new cmake module helpers

### DIFF
--- a/cmake/modules/FindLibdatachannel.cmake
+++ b/cmake/modules/FindLibdatachannel.cmake
@@ -32,10 +32,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
 
-    add_dependencies(libdatachannel ${APP_NAME_LC}::Libjuice
-                                    ${APP_NAME_LC}::Libsrtp
-                                    ${APP_NAME_LC}::Plog
-                                    ${APP_NAME_LC}::Usrsctp)
+    add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME}
+                     ${APP_NAME_LC}::Libjuice
+                     ${APP_NAME_LC}::Libsrtp
+                     ${APP_NAME_LC}::Plog
+                     ${APP_NAME_LC}::Usrsctp)
   endmacro()
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
@@ -96,8 +97,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                                                        INTERFACE_COMPILE_DEFINITIONS "${_libdatachannel_definitions}")
     endif()
 
-    if(TARGET libdatachannel)
-      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libdatachannel)
+    if(TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
 
     # Add internal build target when a Multi Config Generator is used
@@ -109,11 +110,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # This is mainly targeted for windows who required different runtime libs for different
     # types, and they arent compatible
     if(_multiconfig_generator)
-      if(NOT TARGET libdatachannel)
+      if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
         buildLibdatachannel()
-        set_target_properties(libdatachannel PROPERTIES EXCLUDE_FROM_ALL TRUE)
+        set_target_properties(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
       endif()
-      add_dependencies(build_internal_depends libdatachannel)
+      add_dependencies(build_internal_depends ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
   else()
     if(Libdatachannel_FIND_REQUIRED)

--- a/cmake/modules/FindLibtorrent.cmake
+++ b/cmake/modules/FindLibtorrent.cmake
@@ -35,10 +35,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
 
-    add_dependencies(${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}
-      ${APP_NAME_LC}::Boost
-      ${APP_NAME_LC}::Libdatachannel
-      ${APP_NAME_LC}::try_signal)
+    add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME}
+                     ${APP_NAME_LC}::Boost
+                     ${APP_NAME_LC}::Libdatachannel
+                     ${APP_NAME_LC}::try_signal)
   endmacro()
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
@@ -105,8 +105,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                                                             INTERFACE_LINK_LIBRARIES "-framework SystemConfiguration")
     endif()
 
-    if(TARGET libtorrent)
-      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libtorrent)
+    if(TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
 
     # Add internal build target when a Multi Config Generator is used
@@ -118,11 +118,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # This is mainly targeted for windows who required different runtime libs for different
     # types, and they arent compatible
     if(_multiconfig_generator)
-      if(NOT TARGET libtorrent)
+      if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
         buildLibtorrent()
-        set_target_properties(libtorrent PROPERTIES EXCLUDE_FROM_ALL TRUE)
+        set_target_properties(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
       endif()
-      add_dependencies(build_internal_depends libtorrent)
+      add_dependencies(build_internal_depends ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
   else()
     if(Libtorrent_FIND_REQUIRED)


### PR DESCRIPTION
## Summary
- fix the build target names in `FindLibdatachannel.cmake`
- fix the build target names in `FindLibtorrent.cmake`

These modules were using hard-coded target names (`libdatachannel` and `libtorrent`). After the CMake refactor they should use `${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME}` which expands to the actual external project target.

## Testing
- `cmake .. -DAPP_RENDER_SYSTEM=gl` *(fails: Could NOT find UDEV)*

------
https://chatgpt.com/codex/tasks/task_e_683e5734b3088326b344925887604ddf