### PR TITLE
Fix dependencies for new cmake module helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ option(ENABLE_PYTHON      "Enable python support?" ON)
 option(ENABLE_TESTING     "Enable testing support?" ON)
 
 # Internal Depends - supported on all platforms
+option(ENABLE_INTERNAL_LIBDATACHANNEL "Enable internal libdatachannel?" ON) # TODO: Change to OFF
+option(ENABLE_INTERNAL_LIBJUICE "Enable internal libjuice?" ON) # TODO: Change to OFF
+option(ENABLE_INTERNAL_LIBSRTP "Enable internal libsrtp?" ON) # TODO: Change to OFF
+option(ENABLE_INTERNAL_PLOG "Enable internal plog?" ON) # TODO: Change to OFF
+option(ENABLE_INTERNAL_USRSCTP "Enable internal usrsctp?" ON) # TODO: Change to OFF
 
 # These are required enabled for all CI platforms, and recommended for all builds
 option(ENABLE_INTERNAL_CROSSGUID "Enable internal crossguid?" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,12 +98,16 @@ option(ENABLE_AIRTUNES    "Enable AirTunes support?" ON)
 option(ENABLE_OPTICAL     "Enable optical support?" ON)
 option(ENABLE_PYTHON      "Enable python support?" ON)
 option(ENABLE_TESTING     "Enable testing support?" ON)
+option(ENABLE_KADEMLIA    "Enable Kademlia support?" ON)
 
 # Internal Depends - supported on all platforms
+option(ENABLE_INTERNAL_BOOST "Enable internal boost?" ON) # TODO: Change to OFF
 option(ENABLE_INTERNAL_LIBDATACHANNEL "Enable internal libdatachannel?" ON) # TODO: Change to OFF
 option(ENABLE_INTERNAL_LIBJUICE "Enable internal libjuice?" ON) # TODO: Change to OFF
 option(ENABLE_INTERNAL_LIBSRTP "Enable internal libsrtp?" ON) # TODO: Change to OFF
+option(ENABLE_INTERNAL_LIBTORRENT "Enable internal libtorrent?" ON) # TODO: Change to OFF
 option(ENABLE_INTERNAL_PLOG "Enable internal plog?" ON) # TODO: Change to OFF
+option(ENABLE_INTERNAL_TRY_SIGNAL "Enable internal try_signal?" ON) # TODO: Change to OFF
 option(ENABLE_INTERNAL_USRSCTP "Enable internal usrsctp?" ON) # TODO: Change to OFF
 
 # These are required enabled for all CI platforms, and recommended for all builds
@@ -326,6 +330,13 @@ if(ENABLE_AIRTUNES)
   find_package(Shairplay ${SEARCH_QUIET})
   if(TARGET ${APP_NAME_LC}::Shairplay)
     core_require_dep(Shairplay)
+  endif()
+endif()
+
+if(ENABLE_KADEMLIA)
+  core_optional_dep(Libtorrent)
+  if(TARGET ${APP_NAME_LC}::Libtorrent)
+    core_require_dep(Boost)
   endif()
 endif()
 

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14565,7 +14565,37 @@ msgctxt "#21350"
 msgid "Special"
 msgstr ""
 
-#empty strings from id 21351 to 21357
+#empty strings from id 21351 to 21352
+
+#. Setting for enabling verbose logging of the libtorrent component
+#: xbmc/utils/log.cpp
+msgctxt "#21353"
+msgid "Verbose logging for [B]libtorrent[/B]"
+msgstr ""
+
+#. Setting category for BitTorrent Kademlia DHT (distributed hash table) settings
+#: system/settings/settings.xml
+msgctxt "#21354"
+msgid "Kademlia"
+msgstr ""
+
+#. Description of settings category with label #21354 "Kademlia"
+#: system/settings/settings.xml
+msgctxt "#21355"
+msgid "This category contains the settings for how the Kademlia DHT service is handled."
+msgstr ""
+
+#. Setting to enable the BitTorrent Kademlia DHT (distributed hash table)
+#: system/settings/settings.xml
+msgctxt "#21356"
+msgid "Enable Kademlia DHT"
+msgstr ""
+
+#. Description of setting with label #21356 "Enable BitTorrent support"
+#: system/settings/settings.xml
+msgctxt "#21357"
+msgid "Enables Kademlia distributed hash table support for peer-to-peer communication and data streaming."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#21358"

--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -162,7 +162,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing boost. If version >= BOOST-VERSION file version, dont build
   if(ENABLE_INTERNAL_BOOST)
     # Build lib
-    buildBoost()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildBoost()
+    endif()
   else()
     # TODO
   endif()

--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -1,0 +1,216 @@
+#.rst:
+# FindBoost
+# -------
+# Finds the required boost libraries
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::Boost - The boost library
+#   ${APP_NAME_LC}::Boost::container
+#   ${APP_NAME_LC}::Boost::context
+#   ${APP_NAME_LC}::Boost::coroutine
+#   ${APP_NAME_LC}::Boost::date_time
+#   ${APP_NAME_LC}::Boost::exception
+#   ${APP_NAME_LC}::Boost::json
+#   ${APP_NAME_LC}::Boost::random
+#   Boost::container
+#   Boost::context
+#   Boost::coroutine
+#   Boost::date_time
+#   Boost::exception
+#   Boost::json
+#   Boost::random
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildBoost)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-Conditionally-define-BOOST_ALL_NO_EMBEDDED_GDB_SCRIP.patch")
+
+    generate_patchcommand("${patches}")
+
+    # Boost libs used by libtorrent
+    set(BOOST_LIBS container
+                   context
+                   coroutine
+                   date_time
+                   exception
+                   json
+                   random)
+
+    # Header only libs required
+    set(BOOST_HEADER_ONLY asio
+                          beast
+                          crc
+                          config
+                          core
+                          logic
+                          multi_index
+                          optional
+                          system
+                          multiprecision
+                          pool)
+
+    set(BOOST_INCLUDE_LIBS_LIST ${BOOST_LIBS} ${BOOST_HEADER_ONLY})
+
+    # We use the semicolon genex to pass through the semicolon separated list to the
+    # externalproject_add call
+    STRING(REPLACE ";" "\$\<SEMICOLON\>" BOOST_INCLUDE_LIBS "${BOOST_INCLUDE_LIBS_LIST}")
+
+    # Darwin platforms use clang for ASM compilation with the context lib
+    # we need to pass -arch flag in particular, but we will just pass CFLAGS
+    # generically.
+    if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      set(CMAKE_EXTRA_ARGS "-DCMAKE_ASM_FLAGS=${CMAKE_C_FLAGS}")
+    endif()
+
+    # For our own sanity, just use unversioned system layout. Lib names then also
+    # dont append toolset info eg.
+    #   versioned: libboost_container-vc142-mt-x64-1_85.lib
+    #   system:    libboost_container.lib
+    if(WIN32 OR WINDOWS_STORE)
+      list(APPEND CMAKE_EXTRA_ARGS "-DBOOST_INSTALL_LAYOUT=system")
+    endif()
+
+    if(WINDOWS_STORE)
+      # ToDo: warning LNK4264: archiving object file compiled with /ZW into a static library; note
+      #       that when authoring Windows Runtime types it is not recommended to link with a static library 
+      #       that contains Windows Runtime metadata unless /WHOLEARCHIVE is specified to include everything 
+      #       from the static library
+      set(BOOST_CXX_FLAGS "-DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00 /ZW /Zc:twoPhase-")
+    endif()
+
+    # Define Boost.Context implementation to use 'fcontext'
+    list(APPEND CMAKE_EXTRA_ARGS "-DBOOST_CONTEXT_IMPLEMENTATION=fcontext")
+
+    # Add BOOST_CONTEXT_ARCHITECTURE to CMake arguments
+    if(WIN32 OR WINDOWS_STORE)
+      # If the generator platform is set (VS multi-arch), we can pick from that
+      if(CMAKE_GENERATOR_PLATFORM MATCHES "Win32")
+        set(BOOST_CONTEXT_ARCHITECTURE "i386")
+      elseif(CMAKE_GENERATOR_PLATFORM MATCHES "x64")
+        set(BOOST_CONTEXT_ARCHITECTURE "x86_64")
+      elseif(CMAKE_GENERATOR_PLATFORM MATCHES "ARM")
+        set(BOOST_CONTEXT_ARCHITECTURE "arm")
+      elseif(CMAKE_GENERATOR_PLATFORM MATCHES "ARM64")
+        set(BOOST_CONTEXT_ARCHITECTURE "arm64")
+      else()
+        message(FATAL_ERROR "Unrecognized generator platform: ${CMAKE_GENERATOR_PLATFORM}")
+      endif()
+    else()
+      # Dynamically determine the BOOST_CONTEXT_ARCHITECTURE based on the
+      # desired system architecture
+      if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i[3-6]86|x86)$")
+        set(BOOST_CONTEXT_ARCHITECTURE "i386")
+      elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
+        set(BOOST_CONTEXT_ARCHITECTURE "x86_64")
+      elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|armv[7-8]|armel|armhf)$")
+        set(BOOST_CONTEXT_ARCHITECTURE "arm")
+      elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+        set(BOOST_CONTEXT_ARCHITECTURE "arm64")
+      else()
+        message(FATAL_ERROR "Unknown CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+      endif()
+    endif()
+    list(APPEND CMAKE_EXTRA_ARGS "-DBOOST_CONTEXT_ARCHITECTURE=${BOOST_CONTEXT_ARCHITECTURE}")
+
+    # Force-disable embedded GDB scripts to avoid build failures on certain
+    # toolchains. This is a workaround for issues related to inline assembly
+    # errors with .debug_gdb_scripts.
+    list(APPEND CMAKE_EXTRA_ARGS "-DBOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS=ON")
+
+    set(CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+                   "-DBOOST_INCLUDE_LIBRARIES=${BOOST_INCLUDE_LIBS}"
+                   -DBUILD_SHARED_LIBS=OFF
+                   ${CMAKE_EXTRA_ARGS})
+
+    BUILD_DEP_TARGET()
+
+    # create target for each boost_lib for linking purposes
+    foreach(lib ${BOOST_LIBS})
+      add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME}::${lib} UNKNOWN IMPORTED)
+
+      if(WIN32 OR WINDOWS_STORE)
+        set(_lib_extension "lib")
+      else()
+        set(_lib_extension "a")
+      endif()
+
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME}::${lib} PROPERTIES
+                                                                               IMPORTED_CONFIGURATIONS RELEASE
+                                                                               IMPORTED_LOCATION_RELEASE "${DEP_LOCATION}/lib/libboost_${lib}.${_lib_extension}")
+
+      if(DEFINED BOOST_DEBUG_POSTFIX)
+        set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME}::${lib} PROPERTIES
+                                                                                 IMPORTED_LOCATION_DEBUG "${DEP_LOCATION}/lib/libboost_${lib}${BOOST_DEBUG_POSTFIX}.${_lib_extension}")
+        set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME}::${lib} APPEND PROPERTY
+                                                                                      IMPORTED_CONFIGURATIONS DEBUG)
+      endif()
+
+      # Create "standard" target aliases for Boost components
+      add_library(Boost::${lib} ALIAS ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME}::${lib})
+    endforeach()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC boost)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing boost. If version >= BOOST-VERSION file version, dont build
+  if(ENABLE_INTERNAL_BOOST)
+    # Build lib
+    buildBoost()
+  else()
+    # TODO
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Boost
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Boost_FOUND)
+    find_package(OpenSSL REQUIRED ${SEARCH_QUIET})
+
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} INTERFACE IMPORTED)
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR};${OPENSSL_INCLUDE_DIR}")
+
+    # Skip linking OpenSSL::Crypto on Windows due to duplicate symbols in the
+    # shairplay library
+    if(NOT WIN32 AND NOT WINDOWS_STORE)
+      set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                            INTERFACE_LINK_LIBRARIES "OpenSSL::Crypto")
+    endif()
+
+    if(TARGET boost)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} boost)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET boost)
+        buildBoost()
+        set_target_properties(boost PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends boost)
+    endif()
+  else()
+    if(Boost_FIND_REQUIRED)
+      message(FATAL_ERROR "boost libraries were not found. You may want to try -DENABLE_INTERNAL_BOOST=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindLibdatachannel.cmake
+++ b/cmake/modules/FindLibdatachannel.cmake
@@ -1,0 +1,123 @@
+#.rst:
+# FindLibdatachannel
+# -------
+# Finds the libdatachannel library
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::Libdatachannel - The libdatachannel library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildLibdatachannel)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-Also-use-static-library-name-in-find_library.patch"
+                "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0002-Only-install-static-library.patch")
+
+    generate_patchcommand("${patches}")
+
+    set(CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF
+                   -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                   -DNO_EXAMPLES=ON
+                   -DNO_TESTS=ON
+                   -DPREFER_SYSTEM_LIB=ON)
+
+    # Set definitions that will be set in the built cmake config file
+    # We dont import the config file if we build internal (chicken/egg scenario)
+    set(_libdatachannel_definitions RTC_STATIC
+                                    RTC_SYSTEM_JUICE=1
+                                    RTC_SYSTEM_SRTP=1)
+
+    BUILD_DEP_TARGET()
+
+    add_dependencies(libdatachannel ${APP_NAME_LC}::Libjuice
+                                    ${APP_NAME_LC}::Libsrtp
+                                    ${APP_NAME_LC}::Plog
+                                    ${APP_NAME_LC}::Usrsctp)
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  # TODO: Check dependencies if we have any intention to build internal
+  if (ENABLE_INTERNAL_LIBDATACHANNEL)
+    find_package(Libjuice REQUIRED ${SEARCH_QUIET})
+    find_package(Libsrtp REQUIRED ${SEARCH_QUIET})
+    find_package(Plog REQUIRED ${SEARCH_QUIET})
+    find_package(Usrsctp REQUIRED ${SEARCH_QUIET})
+  endif()
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC libdatachannel)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing libdatachannel. If version >= LIBDATACHANNEL-VERSION file version, dont build
+  if(ENABLE_INTERNAL_LIBDATACHANNEL)
+    # Build lib
+    buildLibdatachannel()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Libdatachannel
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Libdatachannel_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS RELEASE
+                                                                       IMPORTED_LOCATION_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE}")
+    endif()
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS DEBUG
+                                                                       IMPORTED_LOCATION_DEBUG "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG}")
+    endif()
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_LINK_LIBRARIES "${APP_NAME_LC}::Libjuice;${APP_NAME_LC}::Libsrtp;${APP_NAME_LC}::Usrsctp")
+
+    if(_libdatachannel_definitions)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       INTERFACE_COMPILE_DEFINITIONS "${_libdatachannel_definitions}")
+    endif()
+
+    if(TARGET libdatachannel)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libdatachannel)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET libdatachannel)
+        buildLibdatachannel()
+        set_target_properties(libdatachannel PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends libdatachannel)
+    endif()
+  else()
+    if(Libdatachannel_FIND_REQUIRED)
+      message(FATAL_ERROR "libdatachannel libraries were not found. You may want to try -DENABLE_INTERNAL_LIBDATACHANNEL=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindLibdatachannel.cmake
+++ b/cmake/modules/FindLibdatachannel.cmake
@@ -32,10 +32,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
 
-    add_dependencies(libdatachannel ${APP_NAME_LC}::Libjuice
-                                    ${APP_NAME_LC}::Libsrtp
-                                    ${APP_NAME_LC}::Plog
-                                    ${APP_NAME_LC}::Usrsctp)
+    add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME}
+                     ${APP_NAME_LC}::Libjuice
+                     ${APP_NAME_LC}::Libsrtp
+                     ${APP_NAME_LC}::Plog
+                     ${APP_NAME_LC}::Usrsctp)
   endmacro()
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
@@ -55,7 +56,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing libdatachannel. If version >= LIBDATACHANNEL-VERSION file version, dont build
   if(ENABLE_INTERNAL_LIBDATACHANNEL)
     # Build lib
-    buildLibdatachannel()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildLibdatachannel()
+    endif()
   else()
     # TODO
   endif()
@@ -96,8 +99,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                                                        INTERFACE_COMPILE_DEFINITIONS "${_libdatachannel_definitions}")
     endif()
 
-    if(TARGET libdatachannel)
-      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libdatachannel)
+    if(TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
 
     # Add internal build target when a Multi Config Generator is used
@@ -109,11 +112,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # This is mainly targeted for windows who required different runtime libs for different
     # types, and they arent compatible
     if(_multiconfig_generator)
-      if(NOT TARGET libdatachannel)
+      if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
         buildLibdatachannel()
-        set_target_properties(libdatachannel PROPERTIES EXCLUDE_FROM_ALL TRUE)
+        set_target_properties(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
       endif()
-      add_dependencies(build_internal_depends libdatachannel)
+      add_dependencies(build_internal_depends ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
   else()
     if(Libdatachannel_FIND_REQUIRED)

--- a/cmake/modules/FindLibjuice.cmake
+++ b/cmake/modules/FindLibjuice.cmake
@@ -1,0 +1,102 @@
+#.rst:
+# FindLibjuice
+# -------
+# Finds the libjuice library
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::Libjuice - The libjuice library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildLibjuice)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-CMake-Only-install-static-library.patch")
+
+    generate_patchcommand("${patches}")
+
+    set(CMAKE_ARGS -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                   -DNO_TESTS=ON)
+
+    # Set definitions that will be set in the built cmake config file
+    # We dont import the config file if we build internal (chicken/egg scenario)
+    set(_libjuice_definitions JUICE_STATIC)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC libjuice)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing libjuice. If version >= LIBJUICE-VERSION file version, dont build
+  if(ENABLE_INTERNAL_LIBJUICE)
+    # Build lib
+    buildLibjuice()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Libjuice
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Libjuice_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS RELEASE
+                                                                       IMPORTED_LOCATION_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE}")
+    endif()
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS DEBUG
+                                                                       IMPORTED_LOCATION_DEBUG "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG}")
+    endif()
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+
+    if(_libjuice_definitions)
+      set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                            INTERFACE_COMPILE_DEFINITIONS "${_libjuice_definitions}")
+    endif()
+
+    if(TARGET libjuice)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libjuice)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET libjuice)
+        buildLibjuice()
+        set_target_properties(libjuice PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends libjuice)
+    endif()
+  else()
+    if(Libjuice_FIND_REQUIRED)
+      message(FATAL_ERROR "libjuice libraries were not found. You may want to try -DENABLE_INTERNAL_LIBJUICE=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindLibjuice.cmake
+++ b/cmake/modules/FindLibjuice.cmake
@@ -36,7 +36,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing libjuice. If version >= LIBJUICE-VERSION file version, dont build
   if(ENABLE_INTERNAL_LIBJUICE)
     # Build lib
-    buildLibjuice()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildLibjuice()
+    endif()
   else()
     # TODO
   endif()

--- a/cmake/modules/FindLibsrtp.cmake
+++ b/cmake/modules/FindLibsrtp.cmake
@@ -30,7 +30,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing libsrtp. If version >= LIBSRTP-VERSION file version, dont build
   if(ENABLE_INTERNAL_LIBSRTP)
     # Build lib
-    buildLibsrtp()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildLibsrtp()
+    endif()
   else()
     # TODO
   endif()

--- a/cmake/modules/FindLibsrtp.cmake
+++ b/cmake/modules/FindLibsrtp.cmake
@@ -1,0 +1,91 @@
+#.rst:
+# FindLibsrtp
+# -------
+# Finds the libsrtp library
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::Libsrtp - The libsrtp library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildLibsrtp)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(CMAKE_ARGS -DBUILD_WITH_WARNINGS=OFF
+                   -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                   -DENABLE_OPENSSL=ON
+                   -DLIBSRTP_TEST_APPS=OFF)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC libsrtp)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing libsrtp. If version >= LIBSRTP-VERSION file version, dont build
+  if(ENABLE_INTERNAL_LIBSRTP)
+    # Build lib
+    buildLibsrtp()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Libsrtp
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Libsrtp_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS RELEASE
+                                                                       IMPORTED_LOCATION_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE}")
+    endif()
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS DEBUG
+                                                                       IMPORTED_LOCATION_DEBUG "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG}")
+    endif()
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+
+    if(TARGET libsrtp)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libsrtp)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET libsrtp)
+        buildLibsrtp()
+        set_target_properties(libsrtp PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends libsrtp)
+    endif()
+  else()
+    if(Libsrtp_FIND_REQUIRED)
+      message(FATAL_ERROR "libsrtp libraries were not found. You may want to try -DENABLE_INTERNAL_LIBSRTP=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindLibtorrent.cmake
+++ b/cmake/modules/FindLibtorrent.cmake
@@ -1,0 +1,132 @@
+#.rst:
+# FindLibtorrent
+# -------
+# Finds the libtorrent library
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::Libtorrent - The libtorrent library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildLibtorrent)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-Use-system-libdatachannel-and-try_signal.patch"
+                "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0002-Disable-asserts.patch")
+
+    if(WINDOWS_STORE)
+      list(APPEND patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0003-Disable-Win32-file-API-in-Boost.patch")
+    endif()
+
+    generate_patchcommand("${patches}")
+
+    set(CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF
+                   -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                   -Ddeprecated-functions=OFF
+                   -Dwebtorrent=ON)
+
+    # Set definitions that will be set in the built cmake config file
+    # We dont import the config file if we build internal (chicken/egg scenario)
+    set(_libtorrent_definitions TORRENT_ABI_VERSION=4 # libtorrent-2.1
+                                TORRENT_USE_LIBCRYPTO
+                                TORRENT_USE_OPENSSL)
+
+    BUILD_DEP_TARGET()
+
+    add_dependencies(${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}
+      ${APP_NAME_LC}::Boost
+      ${APP_NAME_LC}::Libdatachannel
+      ${APP_NAME_LC}::try_signal)
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  # TODO: Check dependencies if we have any intention to build internal
+  if (ENABLE_INTERNAL_LIBTORRENT)
+    find_package(Boost REQUIRED ${SEARCH_QUIET})
+    find_package(Libdatachannel REQUIRED ${SEARCH_QUIET})
+    find_package(try_signal REQUIRED ${SEARCH_QUIET})
+  endif()
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC libtorrent)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing libtorrent. If version >= LIBTORRENT-VERSION file version, dont build
+  if(ENABLE_INTERNAL_LIBTORRENT)
+    # Build lib
+    buildLibtorrent()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Libtorrent
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Libtorrent_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS RELEASE
+                                                                       IMPORTED_LOCATION_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE}")
+    endif()
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS DEBUG
+                                                                       IMPORTED_LOCATION_DEBUG "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG}")
+    endif()
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_COMPILE_DEFINITIONS "HAS_LIBTORRENT")
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_LINK_LIBRARIES "${APP_NAME_LC}::Boost;${APP_NAME_LC}::Libdatachannel;${APP_NAME_LC}::try_signal")
+
+    if(_libtorrent_definitions)
+      set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                            INTERFACE_COMPILE_DEFINITIONS "${_libtorrent_definitions}")
+    endif()
+
+    if(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
+      set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                            INTERFACE_LINK_LIBRARIES "-framework SystemConfiguration")
+    endif()
+
+    if(TARGET libtorrent)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libtorrent)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET libtorrent)
+        buildLibtorrent()
+        set_target_properties(libtorrent PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends libtorrent)
+    endif()
+  else()
+    if(Libtorrent_FIND_REQUIRED)
+      message(FATAL_ERROR "libtorrent libraries were not found. You may want to try -DENABLE_INTERNAL_LIBTORRENT=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindLibtorrent.cmake
+++ b/cmake/modules/FindLibtorrent.cmake
@@ -35,10 +35,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
 
-    add_dependencies(${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}
-      ${APP_NAME_LC}::Boost
-      ${APP_NAME_LC}::Libdatachannel
-      ${APP_NAME_LC}::try_signal)
+    add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME}
+                     ${APP_NAME_LC}::Boost
+                     ${APP_NAME_LC}::Libdatachannel
+                     ${APP_NAME_LC}::try_signal)
   endmacro()
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
@@ -57,7 +57,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing libtorrent. If version >= LIBTORRENT-VERSION file version, dont build
   if(ENABLE_INTERNAL_LIBTORRENT)
     # Build lib
-    buildLibtorrent()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildLibtorrent()
+    endif()
   else()
     # TODO
   endif()
@@ -105,8 +107,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                                                             INTERFACE_LINK_LIBRARIES "-framework SystemConfiguration")
     endif()
 
-    if(TARGET libtorrent)
-      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} libtorrent)
+    if(TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
 
     # Add internal build target when a Multi Config Generator is used
@@ -118,11 +120,11 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # This is mainly targeted for windows who required different runtime libs for different
     # types, and they arent compatible
     if(_multiconfig_generator)
-      if(NOT TARGET libtorrent)
+      if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
         buildLibtorrent()
-        set_target_properties(libtorrent PROPERTIES EXCLUDE_FROM_ALL TRUE)
+        set_target_properties(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
       endif()
-      add_dependencies(build_internal_depends libtorrent)
+      add_dependencies(build_internal_depends ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
     endif()
   else()
     if(Libtorrent_FIND_REQUIRED)

--- a/cmake/modules/FindPlog.cmake
+++ b/cmake/modules/FindPlog.cmake
@@ -27,7 +27,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing plog. If version >= PLOG-VERSION file version, dont build
   if(ENABLE_INTERNAL_PLOG)
     # Build lib
-    buildPlog()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildPlog()
+    endif()
   else()
     # TODO
   endif()

--- a/cmake/modules/FindPlog.cmake
+++ b/cmake/modules/FindPlog.cmake
@@ -1,0 +1,76 @@
+#.rst:
+# FindPlog
+# -------
+# Finds the plog library
+#
+# This will define the following target:
+#
+#   ${APP_NAME_LC}::Plog - The plog library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildPlog)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(CMAKE_ARGS -DPLOG_BUILD_SAMPLES=OFF
+                   -DPLOG_INSTALL=ON)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC plog)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing plog. If version >= PLOG-VERSION file version, dont build
+  if(ENABLE_INTERNAL_PLOG)
+    # Build lib
+    buildPlog()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Plog
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Plog_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+
+    if(TARGET plog)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} plog)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET plog)
+        buildPlog()
+        set_target_properties(plog PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends plog)
+    endif()
+  else()
+    if(Plog_FIND_REQUIRED)
+      message(FATAL_ERROR "plog libraries were not found. You may want to try -DENABLE_INTERNAL_PLOG=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindUsrsctp.cmake
+++ b/cmake/modules/FindUsrsctp.cmake
@@ -34,7 +34,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing usrsctp. If version >= USRSCTP-VERSION file version, dont build
   if(ENABLE_INTERNAL_USRSCTP)
     # Build lib
-    buildUsrsctp()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildUsrsctp()
+    endif()
   else()
     # TODO
   endif()

--- a/cmake/modules/FindUsrsctp.cmake
+++ b/cmake/modules/FindUsrsctp.cmake
@@ -1,0 +1,95 @@
+#.rst:
+# FindUsrsctp
+# -------
+# Finds the usrsctp library
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::Usrsctp - The usrsctp library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildUsrsctp)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-Add-CMake-export-targets.patch"
+                "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0002-fix-build-error-on-windows.patch")
+
+    generate_patchcommand("${patches}")
+
+    set(CMAKE_ARGS -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                   -Dsctp_build_programs=OFF
+                   -Dsctp_werror=OFF)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC usrsctp)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing usrsctp. If version >= USRSCTP-VERSION file version, dont build
+  if(ENABLE_INTERNAL_USRSCTP)
+    # Build lib
+    buildUsrsctp()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Usrsctp
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(Usrsctp_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS RELEASE
+                                                                       IMPORTED_LOCATION_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE}")
+    endif()
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS DEBUG
+                                                                       IMPORTED_LOCATION_DEBUG "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG}")
+    endif()
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+
+    if(TARGET usrsctp)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} usrsctp)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET usrsctp)
+        buildUsrsctp()
+        set_target_properties(usrsctp PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends usrsctp)
+    endif()
+  else()
+    if(Usrsctp_FIND_REQUIRED)
+      message(FATAL_ERROR "usrsctp libraries were not found. You may want to try -DENABLE_INTERNAL_USRSCTP=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/Findtry_signal.cmake
+++ b/cmake/modules/Findtry_signal.cmake
@@ -32,7 +32,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # TODO: Check for existing try_signal. If version >= TRY_SIGNAL-VERSION file version, dont build
   if(ENABLE_INTERNAL_TRY_SIGNAL)
     # Build lib
-    buildtry_signal()
+    if(NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      buildtry_signal()
+    endif()
   else()
     # TODO
   endif()

--- a/cmake/modules/Findtry_signal.cmake
+++ b/cmake/modules/Findtry_signal.cmake
@@ -1,0 +1,93 @@
+#.rst:
+# Findtry_signal
+# -------
+# Finds the try_signal library
+#
+# This will define the following targets:
+#
+#   ${APP_NAME_LC}::try_signal - The try_signal library
+#
+
+if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
+  macro(buildtry_signal)
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
+
+    set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/0001-CMake-Add-install-step.patch")
+
+    generate_patchcommand("${patches}")
+
+    set(CMAKE_ARGS -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+                   -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                   -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC try_signal)
+
+  SETUP_BUILD_VARS()
+
+  # TODO: Check for existing try_signal. If version >= TRY_SIGNAL-VERSION file version, dont build
+  if(ENABLE_INTERNAL_TRY_SIGNAL)
+    # Build lib
+    buildtry_signal()
+  else()
+    # TODO
+  endif()
+
+  include(SelectLibraryConfigurations)
+  select_library_configurations(${${CMAKE_FIND_PACKAGE_NAME}_MODULE})
+  unset(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARIES)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(try_signal
+                                    REQUIRED_VARS
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR
+                                    VERSION_VAR
+                                      ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION)
+
+  if(try_signal_FOUND)
+    add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} UNKNOWN IMPORTED)
+
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS RELEASE
+                                                                       IMPORTED_LOCATION_RELEASE "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_RELEASE}")
+    endif()
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG)
+      set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                       IMPORTED_CONFIGURATIONS DEBUG
+                                                                       IMPORTED_LOCATION_DEBUG "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY_DEBUG}")
+    endif()
+
+    set_property(TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} APPEND PROPERTY
+                                                                          INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+
+    if(TARGET try_signal)
+      add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} try_signal)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET try_signal)
+        buildtry_signal()
+        set_target_properties(try_signal PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends try_signal)
+    endif()
+  else()
+    if(try_signal_FIND_REQUIRED)
+      message(FATAL_ERROR "try_signal libraries were not found. You may want to try -DENABLE_INTERNAL_TRY_SIGNAL=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/treedata/common/network.txt
+++ b/cmake/treedata/common/network.txt
@@ -1,2 +1,3 @@
 xbmc/network                           network
+xbmc/network/torrent                   network/torrent
 xbmc/network/websocket                 network/websocket

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -14,6 +14,7 @@ xbmc/interfaces/python/test       test/python
 xbmc/music/test                   test/music
 xbmc/music/tags/test              test/music_tags
 xbmc/network/test                 test/network
+xbmc/network/torrent/test         test/network/torrent
 xbmc/pictures/metadata/test       test/pictures/metadata
 xbmc/playlists/test               test/playlists
 xbmc/pvr/channels/test            test/pvrchannels

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2450,6 +2450,16 @@
         </setting>
       </group>
     </category>
+    <category id="kademlia" label="21354" help="21355">
+      <requirement>HAS_LIBTORRENT</requirement>
+      <group id="1" label="16000">
+        <setting id="services.kademlia" type="boolean" label="21356" help="21357">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
     <category id="airplay" label="1273" help="36602">
       <requirement>HAS_AIRPLAY</requirement>
       <group id="1" label="16000">

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -168,6 +168,7 @@ libbdplus: libaacs libgcrypt libgpg-error
 libbluray: fontconfig freetype2 $(ICONV) udfread libxml2 $(LIBAACS) $(LIBDPLUS) $(APACHEANT)
 libcdio-gplv3: $(ICONV)
 libcdio: $(ICONV)
+libdatachannel: libjuice libsrtp plog usrsctp
 libdisplay-info: hwdata
 libevdev: libudev
 libgcrypt: libgpg-error
@@ -175,6 +176,7 @@ libinput: mtdev libevdev
 libmicrohttpd: gnutls libgcrypt libgpg-error
 libplist: $(ZLIB)
 libpng: $(ZLIB)
+libsrtp: openssl
 libva: libdrm $(LIBVA_DEPS)
 libxml2: $(ZLIB)
 libxslt: libxml2

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -177,6 +177,7 @@ libmicrohttpd: gnutls libgcrypt libgpg-error
 libplist: $(ZLIB)
 libpng: $(ZLIB)
 libsrtp: openssl
+libtorrent: boost libdatachannel openssl try_signal $(ZLIB)
 libva: libdrm $(LIBVA_DEPS)
 libxml2: $(ZLIB)
 libxslt: libxml2

--- a/tools/depends/target/boost/0001-Conditionally-define-BOOST_ALL_NO_EMBEDDED_GDB_SCRIP.patch
+++ b/tools/depends/target/boost/0001-Conditionally-define-BOOST_ALL_NO_EMBEDDED_GDB_SCRIP.patch
@@ -1,0 +1,32 @@
+From 4abddec81efcbf4272c53ac98d9b80e40ff0ae9e Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 16 Feb 2025 16:56:06 -0800
+Subject: [PATCH] Conditionally define BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS in
+ Boost.JSON
+
+Modify Boost.JSON's CMake configuration to only define
+BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS if it is already set.
+
+This ensures the flag is applied consistently when explicitly enabled
+while avoiding unnecessary modifications for builds that do not require it.
+---
+ libs/json/CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libs/json/CMakeLists.txt b/libs/json/CMakeLists.txt
+index da991910..fc3b539c 100644
+--- a/libs/json/CMakeLists.txt
++++ b/libs/json/CMakeLists.txt
+@@ -69,6 +69,9 @@ function(boost_json_setup_properties target)
+     endif()
+     target_compile_features(${target} PUBLIC cxx_constexpr)
+     target_compile_definitions(${target} PUBLIC BOOST_JSON_NO_LIB=1)
++    if(BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS)
++        target_compile_definitions(${target} PUBLIC BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS)
++    endif()
+ 
+     if(BOOST_SUPERPROJECT_VERSION)
+         target_include_directories(${target} PUBLIC "${PROJECT_SOURCE_DIR}/include")
+-- 
+2.48.1
+

--- a/tools/depends/target/boost/BOOST-VERSION
+++ b/tools/depends/target/boost/BOOST-VERSION
@@ -1,0 +1,8 @@
+LIBNAME=boost
+VERSION=1.87.0
+ARCHIVE=$(LIBNAME)-$(VERSION)-cmake.tar.gz
+SHA512=58841872225ba07135235b6d71c19208db2beb99c737b5bc0862a83517552738d750e514eb9908e6f754b35a2392ac48d3c7edd9d5d7b3cac320b569bef1f26c
+BYPRODUCT=stage/lib/libboost_system.a
+
+# TODO
+BASE_URL=https://github.com/boostorg/boost/releases/download/boost-1.87.0

--- a/tools/depends/target/boost/Makefile
+++ b/tools/depends/target/boost/Makefile
@@ -1,0 +1,88 @@
+include ../../Makefile.include
+include BOOST-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  BOOST-VERSION \
+  Makefile
+
+# The comma-separated list of boost libraries to build
+# This list is for libtorrent - required by cmakebuild
+# asio,beast,crc,config,context,core,json,logic,multi_index,optional,system,multiprecision,pool
+# b2 only requires actual linkable lib names
+BOOST_LIBRARIES=context,json,system
+
+# Boost build options
+BOOST_OPTIONS := \
+  link=static \
+  cflags="$(CFLAGS)" \
+  cxxflags="$(CXXFLAGS)" \
+  linkflags="$(LDFLAGS)" \
+  cxxstd=20 \
+
+ifeq ($(DEBUG_BUILD),yes)
+  BOOST_OPTIONS += variant=debug
+else
+  BOOST_OPTIONS += variant=release
+endif
+
+BOOST_OPTIONS += toolset=gcc-cross
+ifneq (,$(findstring arm64,$(CPU)))
+  BOOST_OPTIONS += architecture=arm address-model=64
+else ifneq (,$(findstring arm,$(CPU)))
+  BOOST_OPTIONS += architecture=arm address-model=32
+else ifeq ($(CPU),i686)
+  BOOST_OPTIONS += architecture=x86 address-model=32
+else ifeq ($(CPU),x86_64)
+  BOOST_OPTIONS += architecture=x86 address-model=64
+endif
+
+# TODO: FreeBSD (verify), iOS, tvOS
+ifeq ($(OS),osx)
+  BOOST_OPTIONS += target-os=darwin
+else ifeq ($(OS),darwin_embedded)
+  BOOST_OPTIONS += target-os=darwin
+else
+  BOOST_OPTIONS += target-os=$(OS)
+endif
+
+# The generated library
+LIBDYLIB=$(PLATFORM)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+$(PLATFORM)/b2: $(PLATFORM)
+	cd $(PLATFORM); ./bootstrap.sh \
+	  --prefix=$(PREFIX) \
+	  --with-python=$(NATIVEPREFIX)/bin/python3 \
+	  --with-libraries=$(BOOST_LIBRARIES) \
+	  --without-icu
+ifeq ($(CROSS_COMPILING), yes)
+	echo "using gcc : cross : $(CXX) ;" >> $(PLATFORM)/project-config.jam
+endif
+
+$(LIBDYLIB): $(PLATFORM)/b2
+	cd $(PLATFORM); ./b2 $(BOOST_OPTIONS)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	cd $(PLATFORM); ./b2 $(BOOST_OPTIONS) install
+	touch $@
+
+clean:
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/libdatachannel/0001-Also-use-static-library-name-in-find_library.patch
+++ b/tools/depends/target/libdatachannel/0001-Also-use-static-library-name-in-find_library.patch
@@ -1,0 +1,38 @@
+From 2d4cbf9feb879cb79c58cab9d80812e3097e7ff9 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Fri, 28 Jun 2024 17:02:32 -0700
+Subject: [PATCH 1/2] Also use static library name in find_library
+
+---
+ CMakeLists.txt                   | 2 +-
+ cmake/Modules/FindLibJuice.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fe08cc43..204b55c1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -451,7 +451,7 @@ else()
+ 	if(USE_SYSTEM_JUICE)
+ 		find_package(LibJuice REQUIRED)
+ 		target_compile_definitions(datachannel PRIVATE RTC_SYSTEM_JUICE=1)
+-		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_JUICE=1)
++		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_JUICE=1 JUICE_STATIC)
+ 		target_link_libraries(datachannel PRIVATE LibJuice::LibJuice)
+ 		target_link_libraries(datachannel-static PRIVATE LibJuice::LibJuice)
+ 	else()
+diff --git a/cmake/Modules/FindLibJuice.cmake b/cmake/Modules/FindLibJuice.cmake
+index a255b89b..cf9e9097 100644
+--- a/cmake/Modules/FindLibJuice.cmake
++++ b/cmake/Modules/FindLibJuice.cmake
+@@ -1,6 +1,6 @@
+ if (NOT TARGET LibJuice::LibJuice)
+ 	find_path(JUICE_INCLUDE_DIR juice/juice.h)
+-	find_library(JUICE_LIBRARY NAMES juice)
++	find_library(JUICE_LIBRARY NAMES juice juice-static)
+ 
+ 	include(FindPackageHandleStandardArgs)
+ 	find_package_handle_standard_args(LibJuice DEFAULT_MSG JUICE_LIBRARY JUICE_INCLUDE_DIR)
+-- 
+2.47.1
+

--- a/tools/depends/target/libdatachannel/0002-Only-install-static-library.patch
+++ b/tools/depends/target/libdatachannel/0002-Only-install-static-library.patch
@@ -1,0 +1,34 @@
+From 4b6f6b86ac035728c4b0a8aaac7ceb58dcd85bdd Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Mon, 1 Jul 2024 19:26:00 -0700
+Subject: [PATCH 2/2] Only install static library
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 204b55c1..bca2b110 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -256,7 +256,7 @@ if(APPLE)
+ 		SOVERSION ${PROJECT_VERSION_MAJOR})
+ endif()
+ 
+-add_library(datachannel-static STATIC EXCLUDE_FROM_ALL
++add_library(datachannel-static STATIC
+ 	${LIBDATACHANNEL_SOURCES}
+ 	${LIBDATACHANNEL_HEADERS}
+ 	${LIBDATACHANNEL_IMPL_SOURCES}
+@@ -492,7 +492,7 @@ if(WARNINGS_AS_ERRORS)
+ 	endif()
+ endif()
+ 
+-install(TARGETS datachannel EXPORT LibDataChannelTargets
++install(TARGETS datachannel-static EXPORT LibDataChannelTargets
+ 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-- 
+2.47.1
+

--- a/tools/depends/target/libdatachannel/LIBDATACHANNEL-VERSION
+++ b/tools/depends/target/libdatachannel/LIBDATACHANNEL-VERSION
@@ -1,0 +1,9 @@
+LIBNAME=libdatachannel
+VERSION=0.22.4
+ARCHIVE=v$(VERSION).tar.gz
+SHA512=738bfa45b804cab178426301f97674af4d04b253f45c3caa41b9ec8f658672662e9a7e37a61ee1523b724f3888df85ece86105ae3951aac65a0f2b17fc5b4fac
+BYPRODUCT=libdatachannel-static.a
+BYPRODUCT_WIN=datachannel-static.lib
+
+# TODO
+BASE_URL=https://github.com/paullouisageneau/libdatachannel/archive/refs/tags

--- a/tools/depends/target/libdatachannel/Makefile
+++ b/tools/depends/target/libdatachannel/Makefile
@@ -1,0 +1,54 @@
+include ../../Makefile.include
+include LIBDATACHANNEL-VERSION
+include ../../download-files.include
+
+DEPS := \
+	../../Makefile.include \
+  ../../download-files.include \
+  0001-Also-use-static-library-name-in-find_library.patch \
+  0002-Only-install-static-library.patch \
+  LIBDATACHANNEL-VERSION \
+  Makefile \
+
+CMAKE_OPTIONS := \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DNO_EXAMPLES=ON \
+  -DNO_TESTS=ON \
+  -DPREFER_SYSTEM_LIB=ON \
+  $(CMAKE_OPTIONS) \
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+# Generated library
+LIBDYLIB := $(BUILDDIR)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(BUILDDIR)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../0001-Also-use-static-library-name-in-find_library.patch
+	cd $(PLATFORM); patch -p1 -i ../0002-Only-install-static-library.patch
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(BUILDDIR) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/libjuice/0001-CMake-Only-install-static-library.patch
+++ b/tools/depends/target/libjuice/0001-CMake-Only-install-static-library.patch
@@ -1,0 +1,34 @@
+From 9bee76db155328b3adf02fe43148379d1ab4b8be Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Fri, 28 Jun 2024 16:49:40 -0700
+Subject: [PATCH] CMake: Only install static library
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 840b6ed..49074cb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -100,7 +100,7 @@ target_include_directories(juice PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+ target_compile_definitions(juice PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
+ target_link_libraries(juice PRIVATE Threads::Threads)
+ 
+-add_library(juice-static STATIC EXCLUDE_FROM_ALL ${LIBJUICE_SOURCES})
++add_library(juice-static STATIC ${LIBJUICE_SOURCES})
+ set_target_properties(juice-static PROPERTIES VERSION ${PROJECT_VERSION})
+ target_include_directories(juice-static PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+@@ -147,7 +147,7 @@ add_library(LibJuice::LibJuice ALIAS juice)
+ set_target_properties(juice-static PROPERTIES EXPORT_NAME LibJuiceStatic)
+ add_library(LibJuice::LibJuiceStatic ALIAS juice-static)
+ 
+-install(TARGETS juice EXPORT LibJuiceTargets
++install(TARGETS juice-static EXPORT LibJuiceTargets
+ 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-- 
+2.47.1
+

--- a/tools/depends/target/libjuice/LIBJUICE-VERSION
+++ b/tools/depends/target/libjuice/LIBJUICE-VERSION
@@ -1,0 +1,9 @@
+LIBNAME=libjuice
+VERSION=1.5.8
+ARCHIVE=v$(VERSION).tar.gz
+SHA512=ae68b0589e4ef822d707ff9d147dcf918eccbb38d73edfcb8665d5c263ad1063c12c828933d6884accf9553d3bbe4bf2e57379c2c8b66ea9a51cfbd11b2217b7
+BYPRODUCT=libjuice-static.a
+BYPRODUCT_WIN=juice-static.lib
+
+# TODO
+BASE_URL=https://github.com/paullouisageneau/libjuice/archive/refs/tags

--- a/tools/depends/target/libjuice/Makefile
+++ b/tools/depends/target/libjuice/Makefile
@@ -1,0 +1,51 @@
+include ../../Makefile.include
+include LIBJUICE-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  0001-CMake-Only-install-static-library.patch \
+  LIBJUICE-VERSION  \
+  Makefile \
+
+CMAKE_OPTIONS := \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DNO_TESTS=ON \
+  $(CMAKE_OPTIONS) \
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+# Generated library
+LIBDYLIB := $(BUILDDIR)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); rm -rf build; mkdir -p build
+	cd $(PLATFORM); patch -p1 -i ../0001-CMake-Only-install-static-library.patch
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM)/build clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/libsrtp/LIBSRTP-VERSION
+++ b/tools/depends/target/libsrtp/LIBSRTP-VERSION
@@ -1,0 +1,9 @@
+LIBNAME=libsrtp
+VERSION=2.6.0
+ARCHIVE=v$(VERSION).tar.gz
+SHA512=96f6e2b7300a416a10e5cc45cf67dadf2f4f81119267689cac4296e2dc6d73398457d1a56b651ab4be6da9e701564d3f256bf6d5f42add5eb2b9b9fe8e438a74
+BYPRODUCT=libsrtp2.a
+BYPRODUCT_WIN=srtp2.lib
+
+# TODO
+BASE_URL=https://github.com/cisco/libsrtp/archive

--- a/tools/depends/target/libsrtp/Makefile
+++ b/tools/depends/target/libsrtp/Makefile
@@ -1,0 +1,49 @@
+include ../../Makefile.include
+include LIBSRTP-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  LIBSRTP-VERSION \
+  Makefile \
+
+CMAKE_OPTIONS := \
+  -DBUILD_WITH_WARNINGS=OFF \
+  -DENABLE_OPENSSL=ON \
+  -DLIBSRTP_TEST_APPS=OFF \
+  $(CMAKE_OPTIONS) \
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+# Generated library
+LIBDYLIB := $(BUILDDIR)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(BUILDDIR)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(BUILDDIR) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/libtorrent/0001-Use-system-libdatachannel-and-try_signal.patch
+++ b/tools/depends/target/libtorrent/0001-Use-system-libdatachannel-and-try_signal.patch
@@ -1,0 +1,465 @@
+From 23bc89a5c28d0284de034b6c274f6ad7b85d34a5 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Fri, 28 Jul 2023 16:44:06 -0700
+Subject: [PATCH 1/3] Use system libdatachannel and try_signal
+
+---
+ CMakeLists.txt                         | 40 +++-----------
+ cmake/Modules/FindLibDataChannel.cmake | 59 +++++++++++++++++++++
+ cmake/Modules/FindLibjuice.cmake       | 17 ++++++
+ cmake/Modules/FindLibsrtp.cmake        | 73 ++++++++++++++++++++++++++
+ cmake/Modules/FindPlog.cmake           | 47 +++++++++++++++++
+ cmake/Modules/FindUsrsctp.cmake        | 51 ++++++++++++++++++
+ cmake/Modules/Findtry_signal.cmake     | 51 ++++++++++++++++++
+ 7 files changed, 304 insertions(+), 34 deletions(-)
+ create mode 100644 cmake/Modules/FindLibDataChannel.cmake
+ create mode 100644 cmake/Modules/FindLibjuice.cmake
+ create mode 100644 cmake/Modules/FindLibsrtp.cmake
+ create mode 100644 cmake/Modules/FindPlog.cmake
+ create mode 100644 cmake/Modules/FindUsrsctp.cmake
+ create mode 100644 cmake/Modules/Findtry_signal.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b06d3c4b7..11012161f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,6 +17,8 @@ set (SOVERSION "${VER_MAJOR}.${VER_MINOR}")
+ include(GNUInstallDirs)
+ include(GeneratePkgConfig)
+ 
++find_package(try_signal REQUIRED)
++
+ set(libtorrent_include_files
+ 	add_torrent_params.hpp
+ 	address.hpp
+@@ -294,14 +296,6 @@ set(libtorrent_aux_include_files
+ 	xml_parse.hpp
+ )
+ 
+-set(try_signal_include_files
+-	try_signal
+-	signal_error_code
+-	try_signal_mingw
+-	try_signal_msvc
+-	try_signal_posix
+-)
+-
+ set(sources
+ 	add_torrent_params.cpp
+ 	alert.cpp
+@@ -484,11 +478,6 @@ set(ed25519_sources
+ 	hasher512.cpp
+ )
+ 
+-set(try_signal_sources
+-	try_signal.cpp
+-	signal_error_code.cpp
+-)
+-
+ list(TRANSFORM sources PREPEND "src/")
+ list(TRANSFORM kademlia_sources PREPEND "src/kademlia/")
+ list(TRANSFORM ed25519_sources PREPEND "src/ed25519/")
+@@ -496,7 +485,6 @@ list(TRANSFORM libtorrent_include_files PREPEND "include/libtorrent/")
+ list(TRANSFORM libtorrent_extensions_include_files PREPEND "include/libtorrent/extensions/")
+ list(TRANSFORM libtorrent_aux_include_files PREPEND "include/libtorrent/aux_/")
+ list(TRANSFORM libtorrent_kademlia_include_files PREPEND "include/libtorrent/kademlia/")
+-list(TRANSFORM try_signal_sources PREPEND "deps/try_signal/")
+ 
+ # these options control target creation and thus have to be declared before the add_library() call
+ feature_option(BUILD_SHARED_LIBS "build libtorrent as a shared library" ON)
+@@ -519,7 +507,6 @@ endif()
+ 
+ add_library(torrent-rasterbar
+ 	${sources}
+-	${try_signal_sources}
+ 	${libtorrent_include_files}
+ 	${libtorrent_extensions_include_files}
+ 	${libtorrent_aux_include_files}
+@@ -549,7 +536,6 @@ set_target_properties(torrent-rasterbar
+ target_include_directories(torrent-rasterbar PUBLIC
+ 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+ 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-	PRIVATE deps/try_signal
+ )
+ 
+ target_compile_definitions(torrent-rasterbar
+@@ -575,6 +561,7 @@ endif()
+ target_link_libraries(torrent-rasterbar
+ 	PUBLIC
+ 		Threads::Threads
++		try_signal::try_signal
+ )
+ 
+ if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+@@ -825,23 +812,6 @@ else()
+ 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_DISABLE_DHT)
+ endif()
+ 
+-if (webtorrent)
+-	option(NO_WEBSOCKET "Disable WebSocket support in libdatachannel" ON)
+-	option(NO_MEDIA "Disable media transport support in libdatachannel" ON)
+-	if(GNUTLS_FOUND)
+-		option(USE_GNUTLS "Use GnuTLS instead of OpenSSL for libdatachannel" ON)
+-	else()
+-		option(USE_GNUTLS "Use GnuTLS instead of OpenSSL for libdatachannel" OFF)
+-	endif()
+-	add_subdirectory(deps/libdatachannel EXCLUDE_FROM_ALL)
+-	if(CMAKE_CXX_COMPILER_ID MATCHES Clang|GNU)
+-		target_compile_options(datachannel-static PRIVATE
+-			-Wno-pedantic
+-			-Wno-unused-parameter
+-			-Wno-unused-variable)
+-	endif()
+-endif()
+-
+ # Boost
+ find_public_dependency(Boost REQUIRED)
+ target_link_libraries(torrent-rasterbar PUBLIC Boost::headers)
+@@ -927,7 +897,9 @@ include(CheckCXXCompilerFlag)
+ add_subdirectory(bindings)
+ 
+ if(webtorrent)
+-	target_link_libraries(torrent-rasterbar PRIVATE LibDataChannel::LibDataChannelStatic)
++	find_package(LibDataChannel REQUIRED)
++	target_compile_definitions(torrent-rasterbar PRIVATE ${LIBDATACHANNEL_DEFINITIONS})
++	target_link_libraries(torrent-rasterbar PRIVATE ${LIBDATACHANNEL_LIBRARIES})
+ 
+ 	# Boost.JSON was added to Boost in version 1.75
+ 	find_package(Boost OPTIONAL_COMPONENTS json)
+diff --git a/cmake/Modules/FindLibDataChannel.cmake b/cmake/Modules/FindLibDataChannel.cmake
+new file mode 100644
+index 000000000..8fa574ba2
+--- /dev/null
++++ b/cmake/Modules/FindLibDataChannel.cmake
+@@ -0,0 +1,59 @@
++# FindLibDataChannel
++# -------
++# Finds the libdatachannel library
++#
++# This will define the following variables::
++#
++#   LIBDATACHANNEL_FOUND - system has libdatachannel
++#   LIBDATACHANNEL_INCLUDE_DIRS - the libdatachannel include directory
++#   LIBDATACHANNEL_LIBRARIES - the libdatachannel libraries
++#   LIBDATACHANNEL_DEFINITIONS - the libdatachannel compiler definitions
++#
++# and the following imported targets::
++#
++#   LibDataChannel::LibDataChannel - The libdatachannel library
++#
++
++find_package(Libjuice REQUIRED QUIET)
++find_package(Libsrtp REQUIRED QUIET)
++find_package(Plog REQUIRED QUIET)
++find_package(Usrsctp REQUIRED QUIET)
++
++set(LIBDATACHANNEL_DEPENDENCIES
++  Libjuice::Libjuice
++  libsrtp::libsrtp
++  plog::plog
++  Usrsctp::Usrsctp)
++
++# Populate paths for find_package_handle_standard_args
++find_path(LIBDATACHANNEL_INCLUDE_DIR rtc/rtc.hpp)
++find_library(LIBDATACHANNEL_LIBRARY NAMES datachannel datachannel-static)
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(LibDataChannel
++  REQUIRED_VARS
++    LIBDATACHANNEL_LIBRARY
++    LIBDATACHANNEL_INCLUDE_DIR
++  VERSION_VAR
++    LIBDATACHANNEL_VERSION)
++
++if(LIBDATACHANNEL_FOUND)
++  set(LIBDATACHANNEL_INCLUDE_DIRS ${LIBDATACHANNEL_INCLUDE_DIR})
++  set(LIBDATACHANNEL_LIBRARIES ${LIBDATACHANNEL_LIBRARY})
++  set(LIBDATACHANNEL_DEFINITIONS RTC_STATIC)
++
++  if(NOT TARGET LibDataChannel::LibDataChannel)
++    add_library(LibDataChannel::LibDataChannel UNKNOWN IMPORTED)
++
++    set_target_properties(LibDataChannel::LibDataChannel PROPERTIES
++      IMPORTED_LOCATION "${LIBDATACHANNEL_LIBRARY}"
++      INTERFACE_COMPILE_DEFINITIONS ${LIBDATACHANNEL_DEFINITIONS}
++      INTERFACE_INCLUDE_DIRECTORIES "${LIBDATACHANNEL_INCLUDE_DIR}")
++
++    add_dependencies(LibDataChannel::LibDataChannel ${LIBDATACHANNEL_DEPENDENCIES})
++  endif()
++endif()
++
++mark_as_advanced(LIBDATACHANNEL_INCLUDE_DIR)
++mark_as_advanced(LIBDATACHANNEL_LIBRARY)
++mark_as_advanced(LIBDATACHANNEL_DEPENDENCIES)
+diff --git a/cmake/Modules/FindLibjuice.cmake b/cmake/Modules/FindLibjuice.cmake
+new file mode 100644
+index 000000000..e3e90a3c1
+--- /dev/null
++++ b/cmake/Modules/FindLibjuice.cmake
+@@ -0,0 +1,17 @@
++if (NOT TARGET LibJuice::LibJuice)
++	find_path(JUICE_INCLUDE_DIR juice/juice.h)
++	find_library(JUICE_LIBRARY NAMES juice juice-static)
++
++	include(FindPackageHandleStandardArgs)
++	find_package_handle_standard_args(Libjuice DEFAULT_MSG JUICE_LIBRARY JUICE_INCLUDE_DIR)
++
++    if (Libjuice_FOUND)
++        add_library(LibJuice::LibJuice UNKNOWN IMPORTED)
++        set_target_properties(LibJuice::LibJuice PROPERTIES
++            IMPORTED_LOCATION "${JUICE_LIBRARY}"
++            INTERFACE_INCLUDE_DIRECTORIES "${JUICE_INCLUDE_DIRS}"
++            INTERFACE_LINK_LIBRARIES "${JUICE_LIBRARIES}"
++                IMPORTED_LINK_INTERFACE_LANGUAGES "C")
++    endif ()
++endif ()
++
+diff --git a/cmake/Modules/FindLibsrtp.cmake b/cmake/Modules/FindLibsrtp.cmake
+new file mode 100644
+index 000000000..20e77387a
+--- /dev/null
++++ b/cmake/Modules/FindLibsrtp.cmake
+@@ -0,0 +1,73 @@
++############################################################################
++# FindSRTP.txt
++# Copyright (C) 2014  Belledonne Communications, Grenoble France
++#
++############################################################################
++#
++# This program is free software; you can redistribute it and/or
++# modify it under the terms of the GNU General Public License
++# as published by the Free Software Foundation; either version 2
++# of the License, or (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program; if not, write to the Free Software
++# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
++#
++############################################################################
++#
++# - Find the SRTP include file and library
++#
++#  SRTP_FOUND - system has SRTP
++#  SRTP_INCLUDE_DIRS - the SRTP include directory
++#  SRTP_LIBRARIES - The libraries needed to use SRTP
++
++set(_SRTP_ROOT_PATHS
++	${CMAKE_INSTALL_PREFIX}
++)
++
++find_path(SRTP2_INCLUDE_DIRS
++	NAMES srtp2/srtp.h
++	HINTS _SRTP_ROOT_PATHS
++	PATH_SUFFIXES include
++)
++
++if(SRTP2_INCLUDE_DIRS)
++	set(HAVE_SRTP_SRTP_H 1)
++	set(SRTP_INCLUDE_DIRS ${SRTP2_INCLUDE_DIRS})
++	set(SRTP_VERSION 2)
++	find_library(SRTP_LIBRARIES
++		NAMES srtp2
++		HINTS ${_SRTP_ROOT_PATHS}
++		PATH_SUFFIXES bin lib
++	)
++else()
++	find_path(SRTP_INCLUDE_DIRS
++		NAMES srtp/srtp.h
++		HINTS _SRTP_ROOT_PATHS
++		PATH_SUFFIXES include
++	)
++	if(SRTP_INCLUDE_DIRS)
++		set(HAVE_SRTP_SRTP_H 1)
++		set(SRTP_VERSION 1)
++	endif()
++	find_library(SRTP_LIBRARIES
++	NAMES srtp
++	HINTS ${_SRTP_ROOT_PATHS}
++	PATH_SUFFIXES bin lib
++)
++endif()
++
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(Libsrtp
++	DEFAULT_MSG
++	SRTP_INCLUDE_DIRS SRTP_LIBRARIES HAVE_SRTP_SRTP_H SRTP_VERSION
++)
++
++mark_as_advanced(SRTP_INCLUDE_DIRS SRTP_LIBRARIES HAVE_SRTP_SRTP_H SRTP_VERSION)
++
+diff --git a/cmake/Modules/FindPlog.cmake b/cmake/Modules/FindPlog.cmake
+new file mode 100644
+index 000000000..f114f9985
+--- /dev/null
++++ b/cmake/Modules/FindPlog.cmake
+@@ -0,0 +1,47 @@
++#[=======================================================================[.rst
++Findplog
++----------
++
++FindModule for Plog library
++
++Imported Targets
++^^^^^^^^^^^^^^^^
++
++This module defines the :prop_tgt:`IMPORTED` target ``plog::plog``.
++
++Result Variables
++^^^^^^^^^^^^^^^^
++
++This module sets the following variables:
++
++``plog_FOUND``
++  True, if the library was found.
++
++Cache variables
++^^^^^^^^^^^^^^^
++
++The following cache variables may also be set:
++
++``plog_INCLUDE_DIR``
++  Directory containing ``plog/Log.h``.
++
++#]=======================================================================]
++
++include(FindPackageHandleStandardArgs)
++
++find_path(
++  plog_INCLUDE_DIR
++  NAMES plog/Log.h
++  PATHS /usr/include /usr/local/include)
++
++find_package_handle_standard_args(
++  Plog
++  REQUIRED_VARS plog_INCLUDE_DIR)
++mark_as_advanced(plog_INCLUDE_DIR)
++
++if(Plog_FOUND)
++  if(NOT TARGET plog::plog)
++    add_library(plog::plog INTERFACE IMPORTED)
++    set_target_properties(plog::plog PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${plog_INCLUDE_DIR}")
++  endif()
++endif()
+diff --git a/cmake/Modules/FindUsrsctp.cmake b/cmake/Modules/FindUsrsctp.cmake
+new file mode 100644
+index 000000000..577bbc662
+--- /dev/null
++++ b/cmake/Modules/FindUsrsctp.cmake
+@@ -0,0 +1,51 @@
++#[=======================================================================[.rst
++FindUsrsctp
++----------
++
++FindModule for Usrsctp library
++
++Imported Targets
++^^^^^^^^^^^^^^^^
++
++This module defines the :prop_tgt:`IMPORTED` target ``Usrsctp::Usrsctp``.
++
++Result Variables
++^^^^^^^^^^^^^^^^
++
++This module sets the following variables:
++
++``Usrsctp_FOUND``
++  True, if the library was found.
++
++#]=======================================================================]
++
++include(FindPackageHandleStandardArgs)
++
++find_path(
++  Usrsctp_INCLUDE_DIR
++  NAMES usrsctp.h
++  PATHS /usr/include /usr/local/include)
++
++find_library(
++Usrsctp_LIBRARY
++  NAMES usrsctp libusrsctp
++  PATHS /usr/lib /usr/local/lib)
++
++find_package_handle_standard_args(
++  Usrsctp
++  REQUIRED_VARS Usrsctp_LIBRARY Usrsctp_INCLUDE_DIR)
++mark_as_advanced(Usrsctp_INCLUDE_DIR Usrsctp_LIBRARY)
++
++if(Usrsctp_FOUND)
++  if(NOT TARGET Usrsctp::Usrsctp)
++    if(IS_ABSOLUTE "${Usrsctp_LIBRARY}")
++      add_library(Usrsctp::Usrsctp UNKNOWN IMPORTED)
++      set_property(TARGET Usrsctp::Usrsctp PROPERTY IMPORTED_LOCATION "${Usrsctp_LIBRARY}")
++    else()
++      add_library(Usrsctp::Usrsctp INTERFACE IMPORTED)
++      set_property(TARGET Usrsctp::Usrsctp PROPERTY IMPORTED_LIBNAME "${Usrsctp_LIBRARY}")
++    endif()
++
++    set_target_properties(Usrsctp::Usrsctp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Usrsctp_INCLUDE_DIR}")
++  endif()
++endif()
+diff --git a/cmake/Modules/Findtry_signal.cmake b/cmake/Modules/Findtry_signal.cmake
+new file mode 100644
+index 000000000..18f41a933
+--- /dev/null
++++ b/cmake/Modules/Findtry_signal.cmake
+@@ -0,0 +1,51 @@
++#[=======================================================================[.rst
++Findtry_signal
++----------
++
++FindModule for try_signal library
++
++Imported Targets
++^^^^^^^^^^^^^^^^
++
++This module defines the :prop_tgt:`IMPORTED` target ``try_signal::try_signal``.
++
++Result Variables
++^^^^^^^^^^^^^^^^
++
++This module sets the following variables:
++
++``TRY_SIGNAL_FOUND``
++  True, if the library was found.
++
++Cache variables
++^^^^^^^^^^^^^^^
++
++The following cache variables may also be set:
++
++``TRY_SIGNAL_INCLUDE_DIR``
++  Directory containing ``try_signal.hpp``.
++
++#]=======================================================================]
++
++include(FindPackageHandleStandardArgs)
++
++# Populate paths for find_package_handle_standard_args
++find_path(TRY_SIGNAL_INCLUDE_DIR NAMES try_signal.hpp)
++find_library(TRY_SIGNAL_LIBRARY NAMES try_signal)
++
++find_package_handle_standard_args(try_signal
++  REQUIRED_VARS
++    TRY_SIGNAL_LIBRARY
++    TRY_SIGNAL_INCLUDE_DIR)
++
++if(TRY_SIGNAL_FOUND)
++  if(NOT TARGET try_signal::try_signal)
++    add_library(try_signal::try_signal INTERFACE IMPORTED)
++    set_target_properties(try_signal::try_signal PROPERTIES
++      IMPORTED_LOCATION "${TRY_SIGNAL_LIBRARY}"
++      INTERFACE_INCLUDE_DIRECTORIES "${TRY_SIGNAL_INCLUDE_DIR}")
++  endif()
++endif()
++
++mark_as_advanced(TRY_SIGNAL_INCLUDE_DIR)
++mark_as_advanced(TRY_SIGNAL_LIBRARY)
+-- 
+2.47.1
+

--- a/tools/depends/target/libtorrent/0002-Disable-asserts.patch
+++ b/tools/depends/target/libtorrent/0002-Disable-asserts.patch
@@ -1,0 +1,24 @@
+From 0fe9e6d98ec3680980e91d10b37fb90c128809c5 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Thu, 17 Aug 2023 21:16:52 -0700
+Subject: [PATCH 2/3] Disable asserts
+
+---
+ CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11012161f..2782c9732 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -540,7 +540,6 @@ target_include_directories(torrent-rasterbar PUBLIC
+ 
+ target_compile_definitions(torrent-rasterbar
+ 	PUBLIC
+-		$<$<CONFIG:Debug>:TORRENT_USE_ASSERTS>
+ 		BOOST_ASIO_ENABLE_CANCELIO
+ 		BOOST_ASIO_NO_DEPRECATED
+ 		BOOST_SYSTEM_USE_UTF8
+-- 
+2.47.1
+

--- a/tools/depends/target/libtorrent/0003-Disable-Win32-file-API-in-Boost.patch
+++ b/tools/depends/target/libtorrent/0003-Disable-Win32-file-API-in-Boost.patch
@@ -1,0 +1,24 @@
+From 6316e87d49d5f9e34f56becec294537b5ab28a66 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Wed, 25 Dec 2024 14:41:44 -0800
+Subject: [PATCH 3/3] Disable Win32 file API in Boost
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2782c9732..97c422fdd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -544,6 +544,7 @@ target_compile_definitions(torrent-rasterbar
+ 		BOOST_ASIO_NO_DEPRECATED
+ 		BOOST_SYSTEM_USE_UTF8
+ 		_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING
++		BOOST_BEAST_USE_WIN32_FILE=0
+ 	PRIVATE
+ 		TORRENT_BUILDING_LIBRARY
+ 		BOOST_EXCEPTION_DISABLE
+-- 
+2.47.1
+

--- a/tools/depends/target/libtorrent/LIBTORRENT-VERSION
+++ b/tools/depends/target/libtorrent/LIBTORRENT-VERSION
@@ -1,0 +1,9 @@
+LIBNAME=libtorrent
+VERSION=62eae38e4beb80f8290dd230eb008830f5324b11
+ARCHIVE=$(VERSION).tar.gz
+SHA512=ca42ffe18b5dd9c76104e320edc33e8762e1e57428dbcb241c032025c62ed2cd04609e252da918846578d95027adab9a2b7f5637c4aa3b2159863e74173e86b9
+BYPRODUCT=libtorrent-rasterbar.a
+BYPRODUCT_WIN=torrent-rasterbar.lib
+
+# TODO
+BASE_URL=https://github.com/arvidn/libtorrent/archive

--- a/tools/depends/target/libtorrent/Makefile
+++ b/tools/depends/target/libtorrent/Makefile
@@ -1,0 +1,54 @@
+include ../../Makefile.include
+include LIBTORRENT-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  0001-Use-system-libdatachannel-and-try_signal.patch \
+  0002-Disable-asserts.patch \
+  LIBTORRENT-VERSION \
+  Makefile \
+
+CMAKE_OPTIONS := \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_CXX_STANDARD=17 \
+  -Ddeprecated-functions=OFF \
+  -Dwebtorrent=ON \
+  $(CMAKE_OPTIONS)
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+# Generated library
+LIBDYLIB := $(BUILDDIR)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(BUILDDIR)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../0001-Use-system-libdatachannel-and-try_signal.patch
+	cd $(PLATFORM); patch -p1 -i ../0002-Disable-asserts.patch
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(BUILDDIR) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/plog/Makefile
+++ b/tools/depends/target/plog/Makefile
@@ -1,0 +1,43 @@
+include ../../Makefile.include
+include PLOG-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  Makefile \
+  PLOG-VERSION \
+
+CMAKE_OPTIONS := \
+  -DPLOG_BUILD_SAMPLES=OFF \
+  -DPLOG_INSTALL=ON \
+  $(CMAKE_OPTIONS) \
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(BUILDDIR)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(BUILDDIR) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/plog/PLOG-VERSION
+++ b/tools/depends/target/plog/PLOG-VERSION
@@ -1,0 +1,7 @@
+LIBNAME=plog
+VERSION=1.1.10
+ARCHIVE=$(VERSION).tar.gz
+SHA512=b1d55baadbd16bafa5165b05352f367455b51f2eec2102f1ebad2e6a049954d1b87ffdd96811b0acea2313877db1db837f780971fd027d0db683fe42aeb29573
+
+# TODO
+BASE_URL=https://github.com/SergiusTheBest/plog/archive/refs/tags

--- a/tools/depends/target/try_signal/0001-CMake-Add-install-step.patch
+++ b/tools/depends/target/try_signal/0001-CMake-Add-install-step.patch
@@ -1,0 +1,24 @@
+From 994d3a0a25533ef5d635fc25f87e2c190b52a24a Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Wed, 30 Aug 2023 02:32:03 -0700
+Subject: [PATCH] CMake: Add install step
+
+---
+ CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 945cd6c..a2f61e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,3 +4,7 @@ project(try_signal)
+ add_library(try_signal signal_error_code try_signal)
+ target_include_directories(try_signal PUBLIC .)
+ 
++file(GLOB HEADERS "*.hpp")
++
++install(TARGETS try_signal DESTINATION lib)
++install(FILES ${HEADERS} DESTINATION include)
+-- 
+2.47.1
+

--- a/tools/depends/target/try_signal/Makefile
+++ b/tools/depends/target/try_signal/Makefile
@@ -1,0 +1,45 @@
+include ../../Makefile.include
+include TRY_SIGNAL-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  0001-CMake-Add-install-step.patch \
+  Makefile \
+  TRY_SIGNAL-VERSION \
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+# Generated library
+LIBDYLIB := $(BUILDDIR)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(BUILDDIR)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../0001-CMake-Add-install-step.patch
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(BUILDDIR) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/try_signal/TRY_SIGNAL-VERSION
+++ b/tools/depends/target/try_signal/TRY_SIGNAL-VERSION
@@ -1,0 +1,9 @@
+LIBNAME=try_signal
+VERSION=105cce59972f925a33aa6b1c3109e4cd3caf583d
+ARCHIVE=$(VERSION).tar.gz
+SHA512=4a0090755831e0e4a1930817345fa5934144421d9a9d710fe8ed3712233fa2fa037fc0e0d4f88b7cc8fb1bc05fe2d55372af1ff47d6fbf5208e03f45f2a424e4
+BYPRODUCT=libtry_signal.a
+BYPRODUCT_WIN=try_signal.lib
+
+# TODO
+BASE_URL=https://github.com/arvidn/try_signal/archive

--- a/tools/depends/target/usrsctp/0001-Add-CMake-export-targets.patch
+++ b/tools/depends/target/usrsctp/0001-Add-CMake-export-targets.patch
@@ -1,0 +1,44 @@
+From d45ac729b535858f7cd733d959441940db52dab9 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Fri, 28 Jul 2023 17:11:47 -0700
+Subject: [PATCH 1/2] Add CMake export targets
+
+---
+ usrsctplib/CMakeLists.txt | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/usrsctplib/CMakeLists.txt b/usrsctplib/CMakeLists.txt
+index 93f6f4d..455b468 100644
+--- a/usrsctplib/CMakeLists.txt
++++ b/usrsctplib/CMakeLists.txt
+@@ -184,8 +184,6 @@ list(APPEND usrsctp_sources
+ 
+ add_library(usrsctp ${usrsctp_sources} ${usrsctp_headers})
+ 
+-target_include_directories(usrsctp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+-
+ if(SCTP_USE_MBEDTLS_SHA1)
+ 	target_include_directories(usrsctp PRIVATE ${MBEDTLS_INCLUDE_DIRS})
+ endif()
+@@ -209,9 +207,17 @@ set_target_properties(usrsctp PROPERTIES SOVERSION ${SOVERSION_SHORT} VERSION ${
+ # INSTALL LIBRARY AND HEADER
+ #################################################
+ 
+-install(TARGETS usrsctp DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(TARGETS usrsctp EXPORT UsrsctpConfig DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES usrsctp.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
++# Export Targets
++install(
++	EXPORT UsrsctpConfig
++	FILE UsrsctpConfig.cmake
++	NAMESPACE Usrsctp::
++	DESTINATION lib/cmake/Usrsctp
++)
++
+ #################################################
+ # GENERATE AND INSTALL PKG-CONFIG FILE
+ #################################################
+-- 
+2.37.0.windows.1
+

--- a/tools/depends/target/usrsctp/0002-fix-build-error-on-windows.patch
+++ b/tools/depends/target/usrsctp/0002-fix-build-error-on-windows.patch
@@ -1,0 +1,33 @@
+From 2d36d6f7fbf440d7bd33befa7b6ec152f0e18457 Mon Sep 17 00:00:00 2001
+From: Aven <aven@ocr.one>
+Date: Thu, 4 May 2023 13:22:42 +0800
+Subject: [PATCH 2/2] fix build error on windows
+
+sctp_output.c
+L:\usrsctplib\netinet\sctp_output.c(14823): error C2220: the following warning is treated as an error
+L:\usrsctplib\netinet\sctp_output.c(14823): warning C4703: potentially uninitialized local pointer variable 'inp' used
+L:\usrsctplib\netinet\sctp_output.c(14827): warning C4703: potentially uninitialized local pointer variable 'asoc' used
+---
+ usrsctplib/netinet/sctp_output.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/usrsctplib/netinet/sctp_output.c b/usrsctplib/netinet/sctp_output.c
+index 33a6e16..e47a057 100755
+--- a/usrsctplib/netinet/sctp_output.c
++++ b/usrsctplib/netinet/sctp_output.c
+@@ -13557,10 +13557,10 @@ sctp_lower_sosend(struct socket *so,
+ #endif
+ 	struct timeval now;
+ 	struct sctp_block_entry be;
+-	struct sctp_inpcb *inp;
++	struct sctp_inpcb *inp = NULL;
+ 	struct sctp_tcb *stcb = NULL;
+ 	struct sctp_nets *net;
+-	struct sctp_association *asoc;
++	struct sctp_association *asoc = NULL;
+ 	struct sctp_inpcb *t_inp;
+ 	struct sctp_nonpad_sndrcvinfo *sndrcvninfo;
+ 	ssize_t sndlen = 0, max_len, local_add_more;
+-- 
+2.37.0.windows.1
+

--- a/tools/depends/target/usrsctp/Makefile
+++ b/tools/depends/target/usrsctp/Makefile
@@ -1,0 +1,52 @@
+include ../../Makefile.include
+include USRSCTP-VERSION
+include ../../download-files.include
+
+DEPS := \
+  ../../download-files.include \
+  ../../Makefile.include \
+  0001-Add-CMake-export-targets.patch \
+  0002-fix-build-error-on-windows.patch \
+  Makefile \
+  USRSCTP-VERSION \
+
+CMAKE_OPTIONS := \
+  -Dsctp_build_programs=OFF \
+  -Dsctp_werror=OFF \
+  $(CMAKE_OPTIONS) \
+
+# Build directory
+BUILDDIR := $(PLATFORM)/build
+
+# Generated library
+LIBDYLIB := $(BUILDDIR)/$(BYPRODUCT)
+
+.PHONY: .installed-native
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
+ifeq ($(PREFIX),)
+	@echo
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@exit 1
+endif
+	rm -rf $(PLATFORM); mkdir -p $(BUILDDIR)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../0001-Add-CMake-export-targets.patch
+	cd $(PLATFORM); patch -p1 -i ../0002-fix-build-error-on-windows.patch
+	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(BUILDDIR)
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(BUILDDIR) install
+	touch $@
+
+clean:
+	$(MAKE) -C $(BUILDDIR) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/usrsctp/USRSCTP-VERSION
+++ b/tools/depends/target/usrsctp/USRSCTP-VERSION
@@ -1,0 +1,9 @@
+LIBNAME=usrsctp
+VERSION=b28f0b55b00bde67f6be80d6623e2775b88026b8
+ARCHIVE=$(VERSION).tar.gz
+SHA512=d50de003df24388902f49cf7c2a104e356d8f5199380095f647b8fbb75371185bf25055db9882deef5bfa4faf7c94f611b6ac5cabf31db7bfd876a5a19f9c986
+BYPRODUCT=libusrsctp.a
+BYPRODUCT_WIN=usrsctp.lib
+
+# TODO
+BASE_URL=https://github.com/sctplab/usrsctp/archive

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -61,10 +61,36 @@ void CURL::Parse(std::string strURL1)
   // format 1: protocol://[username:password]@hostname[:port]/directoryandfile
   // format 2: protocol://file
   // format 3: drive:directoryandfile
+  // format 4: magnet:?xt=...
   //
   // first need 2 check if this is a protocol or just a normal drive & path
   if (!strURL.size()) return ;
   if (strURL == "?") return;
+
+  // Magnet URIs aren't standard URLs, so we need to handle them separately
+  if (StringUtils::StartsWith(strURL, "magnet:"))
+  {
+    // Set protocol
+    SetProtocol("magnet");
+
+    // Ignore any protocol slashes that may have been unintentionally added
+    std::string remaining = strURL.substr(std::strlen("magnet:"));
+    remaining.erase(0, remaining.find_first_not_of('/'));
+
+    // Set file name, if one appears before the first ?
+    size_t optionsStart = remaining.find('?');
+    if (optionsStart != std::string::npos)
+    {
+      SetFileName(remaining.substr(0, optionsStart));
+      SetOptions(remaining.substr(optionsStart));
+    }
+    else
+    {
+      SetFileName(remaining);
+    }
+
+    return;
+  }
 
   // form is format 1 or 2
   // format 1: protocol://[domain;][username:password]@hostname[:port]/directoryandfile

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -311,6 +311,14 @@ std::string CUtil::GetTitleFromPath(const std::string& strFileNameAndPath, bool 
 
 std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false */)
 {
+  // Magnet links, use "display name" (dn) option
+  if (url.IsProtocol("magnet"))
+  {
+    std::string strTitle;
+    if (url.GetOption("dn", strTitle))
+      return strTitle;
+  }
+
   // use above to get the filename
   std::string path(url.Get());
   URIUtils::RemoveSlashAtEnd(path);
@@ -1920,6 +1928,13 @@ void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
   {
     videoFileName = URIUtils::ReplaceExtension(URIUtils::GetFileName(videoPath), "");
     basePath = URIUtils::GetBasePath(videoPath);
+  }
+
+  // Preserve magnet URI options
+  if (URIUtils::IsMagnetURI(videoPath))
+  {
+    const CURL url(videoPath);
+    basePath += url.GetOptions();
   }
 }
 

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -45,3 +45,4 @@ constexpr int LOGEPG = (1 << (LOGMASKBIT + 16));
 constexpr int LOGANNOUNCE = (1 << (LOGMASKBIT + 17));
 constexpr int LOGWSDISCOVERY = (1 << (LOGMASKBIT + 18));
 constexpr int LOGADDONS = (1 << (LOGMASKBIT + 19));
+constexpr int LOGLIBTORRENT = (1 << (LOGMASKBIT + 20));

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -453,8 +453,10 @@ void CGUIDialogMediaSource::OnOK()
   share.FromNameAndPaths(m_name, GetPaths());
 
   if (StringUtils::StartsWithNoCase(share.strPath, "plugin://") ||
-    CDirectory::GetDirectory(share.strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) ||
-    CGUIDialogYesNo::ShowAndGetInput(CVariant{ 1001 }, CVariant{ 1025 }))
+      CDirectory::GetDirectory(share.strPath, items, "",
+                               DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) ||
+      StringUtils::StartsWithNoCase(share.strPath, "magnet:") ||
+      CGUIDialogYesNo::ShowAndGetInput(CVariant{1001}, CVariant{1025}))
   {
     m_confirmed = true;
     Close();

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -177,6 +177,15 @@ if(ENABLE_UPNP)
                       UPnPFile.h)
 endif()
 
+if(TARGET ${APP_NAME_LC}::Libtorrent)
+  list(APPEND SOURCES MagnetDirectory.cpp
+                      MagnetFile.cpp
+  )
+  list(APPEND HEADERS MagnetDirectory.h
+                      MagnetFile.h
+  )
+endif()
+
 core_add_library(filesystem)
 if(ENABLE_STATIC_LIBS AND ENABLE_UPNP)
   target_link_libraries(filesystem PRIVATE upnp)

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -84,6 +84,9 @@
 #include "ServiceBroker.h"
 #include "addons/VFSEntry.h"
 #include "utils/StringUtils.h"
+#ifdef HAS_LIBTORRENT
+#include "MagnetDirectory.h"
+#endif
 
 using namespace ADDON;
 
@@ -214,6 +217,11 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
 
   if (url.IsProtocol("pvr"))
     return new CPVRDirectory();
+
+#ifdef HAS_LIBTORRENT
+  if (url.IsProtocol("magnet"))
+    return new CMagnetDirectory();
+#endif
 
   CLog::Log(LOGWARNING, "{} - unsupported protocol({}) in {}", __FUNCTION__, url.GetProtocol(),
             url.GetRedacted());

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -67,6 +67,9 @@
 #include "utils/StringUtils.h"
 #include "ServiceBroker.h"
 #include "addons/VFSEntry.h"
+#ifdef HAS_LIBTORRENT
+#include "MagnetFile.h"
+#endif
 
 using namespace ADDON;
 using namespace XFILE;
@@ -172,6 +175,10 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
 #endif
 #ifdef HAS_UPNP
   else if (url.IsProtocol("upnp")) return new CUPnPFile();
+#endif
+#ifdef HAS_LIBTORRENT
+  else if (url.IsProtocol("magnet"))
+    return new CMagnetFile();
 #endif
 
   CLog::Log(LOGWARNING, "{} - unsupported protocol({}) in {}", __FUNCTION__, url.GetProtocol(),

--- a/xbmc/filesystem/MagnetDirectory.cpp
+++ b/xbmc/filesystem/MagnetDirectory.cpp
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MagnetDirectory.h"
+
+#include "FileItem.h"
+#include "FileItemList.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "network/Network.h"
+#include "network/NetworkServices.h"
+#include "network/torrent/Libtorrent.h"
+#include "network/torrent/TorrentUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <cstring>
+
+#include <libtorrent/libtorrent.hpp>
+
+using namespace KODI;
+using namespace NETWORK;
+using namespace XFILE;
+
+bool CMagnetDirectory::GetDirectory(const CURL& urlOrig, CFileItemList& items)
+{
+  CNetworkServices& networkServices = CServiceBroker::GetNetwork().GetServices();
+  CLibtorrent* libtorrent = dynamic_cast<CLibtorrent*>(networkServices.GetLibtorrent());
+  if (libtorrent == nullptr)
+    return false;
+
+  std::string magnetUri;
+  std::string subdirectory;
+  std::tie(magnetUri, subdirectory) = CTorrentUtils::SplitMagnetURL(urlOrig);
+
+  lt::torrent_handle torrentHandle = libtorrent->AddTorrent(magnetUri);
+  if (!torrentHandle.is_valid())
+    return false;
+
+  std::shared_ptr<const lt::torrent_info> torrentInfo = torrentHandle.torrent_file();
+  if (!torrentInfo)
+    return false;
+
+  const lt::file_storage& files = torrentInfo->files();
+
+  if (files.num_files() == 0)
+  {
+    CLog::Log(LOGERROR, "Torrent has no files!");
+    return false;
+  }
+
+  // Split subdirectory into parts
+  std::vector<std::string> subdirectoryParts = URIUtils::SplitPath(subdirectory);
+
+  // Create a unique set of folders to browse deeper into
+  std::set<std::string> folders;
+
+  // Loop through files and select ones that match the subdirectory
+  for (int i = 0; i < files.num_files(); ++i)
+  {
+    std::string filePath = files.file_path(static_cast<lt::file_index_t>(i));
+    std::vector<std::string> fileParts = URIUtils::SplitPath(filePath);
+
+    if (fileParts.empty() || fileParts.size() - 1 < subdirectoryParts.size())
+      continue;
+
+    // Loop through subdirectory parts and check if they match
+    bool inFolder = true;
+    for (size_t j = 0; j < subdirectoryParts.size(); ++j)
+    {
+      if (fileParts[j] != subdirectoryParts[j])
+      {
+        inFolder = false;
+        break;
+      }
+    }
+    if (!inFolder)
+      continue;
+
+    // Check if this is a file or a folder
+    if (fileParts.size() - subdirectoryParts.size() == 1)
+    {
+      // This is a file in the subdirectory
+      std::time_t modificationTime = files.mtime(static_cast<lt::file_index_t>(i));
+      std::string filePath = files.file_path(static_cast<lt::file_index_t>(i));
+      std::int64_t fileSize = files.file_size(static_cast<lt::file_index_t>(i));
+
+      CURL url = urlOrig;
+      url.SetFileName(filePath);
+
+      CFileItemPtr item = std::make_shared<CFileItem>(URIUtils::GetFileName(filePath));
+      item->SetURL(url);
+      item->m_dateTime = modificationTime;
+      item->m_dwSize = fileSize;
+
+      items.Add(std::move(item));
+    }
+    else if (fileParts.size() - subdirectoryParts.size() > 1)
+    {
+      // Record subdirectory to browse deeper into the torrent
+      std::string folder = fileParts[subdirectoryParts.size()];
+      folders.insert(folder);
+    }
+  }
+
+  // Now add unique subdirectories
+  for (const std::string& folder : folders)
+  {
+    std::string folderPath = URIUtils::AddFileToFolder(subdirectory, folder);
+
+    CURL url = urlOrig;
+    url.SetFileName(folderPath);
+
+    CFileItemPtr item = std::make_shared<CFileItem>(folder);
+    item->SetURL(url);
+    item->m_bIsFolder = true;
+
+    items.Add(std::move(item));
+  }
+
+  if (!subdirectoryParts.empty())
+    items.SetLabel(subdirectoryParts.back());
+
+  return true;
+}
+
+bool CMagnetDirectory::Exists(const CURL& url)
+{
+  CNetworkServices& networkServices = CServiceBroker::GetNetwork().GetServices();
+  CLibtorrent* libtorrent = dynamic_cast<CLibtorrent*>(networkServices.GetLibtorrent());
+  if (libtorrent == nullptr)
+    return false;
+
+  std::string magnetUri;
+  std::string subdirectory;
+  std::tie(magnetUri, subdirectory) = CTorrentUtils::SplitMagnetURL(url);
+
+  lt::torrent_handle torrentHandle = libtorrent->AddTorrent(magnetUri);
+  if (!torrentHandle.is_valid())
+    return false;
+
+  std::shared_ptr<const lt::torrent_info> torrentInfo = torrentHandle.torrent_file();
+  if (!torrentInfo)
+    return false;
+
+  const lt::file_storage& files = torrentInfo->files();
+
+  // Split subdirectory into parts
+  std::vector<std::string> subdirectoryParts = URIUtils::SplitPath(subdirectory);
+
+  // Loop through files looking for one that matches the subdirectory
+  for (int i = 0; i < files.num_files(); ++i)
+  {
+    std::string filePath = files.file_path(static_cast<lt::file_index_t>(i));
+    std::vector<std::string> fileParts = URIUtils::SplitPath(filePath);
+
+    if (fileParts.empty())
+      continue;
+
+    // Loop through subdirectory parts and check if they match
+    bool hasFolder = true;
+    for (size_t j = 0; j < subdirectoryParts.size(); ++j)
+    {
+      if (subdirectoryParts[j] != fileParts[j])
+      {
+        hasFolder = false;
+        break;
+      }
+    }
+    if (hasFolder)
+      return true;
+  }
+
+  return false;
+}
+
+bool CMagnetDirectory::ContainsFiles(const CURL& url)
+{
+  //! @todo
+  return false;
+}

--- a/xbmc/filesystem/MagnetDirectory.h
+++ b/xbmc/filesystem/MagnetDirectory.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IFileDirectory.h"
+
+#include <string>
+#include <utility>
+
+class CURL;
+
+namespace XFILE
+{
+
+class CMagnetDirectory : public IFileDirectory
+{
+public:
+  CMagnetDirectory() = default;
+  ~CMagnetDirectory() override = default;
+
+  // Implementation of IDirectory via IFileDirectory
+  bool GetDirectory(const CURL& url, CFileItemList& items) override;
+  bool Exists(const CURL& url) override;
+  CacheType GetCacheType(const CURL& url) const override { return CacheType::ALWAYS; }
+
+  // Implementation of IFileDirectory
+  bool ContainsFiles(const CURL& url) override;
+};
+
+} // namespace XFILE

--- a/xbmc/filesystem/MagnetFile.cpp
+++ b/xbmc/filesystem/MagnetFile.cpp
@@ -1,0 +1,256 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MagnetFile.h"
+
+#include "MagnetDirectory.h"
+#include "ServiceBroker.h"
+#include "SpecialProtocol.h"
+#include "URL.h"
+#include "network/Network.h"
+#include "network/NetworkServices.h"
+#include "network/torrent/Libtorrent.h"
+#include "network/torrent/TorrentUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <libtorrent/libtorrent.hpp>
+
+using namespace KODI;
+using namespace NETWORK;
+using namespace XFILE;
+
+namespace
+{
+constexpr uint8_t PRIO_HIGHEST = 7;
+constexpr uint8_t PRIO_HIGHER = 6;
+constexpr uint8_t PRIO_HIGH = 5;
+} // namespace
+
+bool CMagnetFile::Open(const CURL& url)
+{
+  CNetworkServices& networkServices = CServiceBroker::GetNetwork().GetServices();
+  CLibtorrent* libtorrent = dynamic_cast<CLibtorrent*>(networkServices.GetLibtorrent());
+  if (libtorrent == nullptr)
+    return false;
+
+  std::string magnetUri;
+  std::string filename;
+  std::tie(magnetUri, filename) = CTorrentUtils::SplitMagnetURL(url);
+
+  m_torrentHandle = libtorrent->AddTorrent(magnetUri);
+  if (!m_torrentHandle.is_valid())
+    return false;
+
+  std::shared_ptr<const lt::torrent_info> torrentInfo = m_torrentHandle.torrent_file();
+  if (!torrentInfo)
+    return false;
+
+  const lt::file_storage& files = torrentInfo->files();
+
+  // Search through files for the matching file
+  for (int i = 0; i < files.num_files(); ++i)
+  {
+    std::string filePath = files.file_path(static_cast<lt::file_index_t>(i));
+
+    if (URIUtils::PathEquals(filename, filePath))
+    {
+      // Found the file, set file parameters
+      m_fileIndex = i;
+      m_fileSize = files.file_size(static_cast<lt::file_index_t>(i));
+      m_modifiedTime = files.mtime(static_cast<lt::file_index_t>(i));
+      m_filePosition = 0;
+      break;
+    }
+  }
+
+  if (m_fileIndex == -1)
+    return false;
+
+  // Set second highest priority to the first and last 0.1% or 128 KiB,
+  // whichever is greater
+  const size_t p01 = static_cast<size_t>(
+      std::max(std::min(static_cast<int64_t>(std::numeric_limits<int>::max()), m_fileSize / 1000),
+               static_cast<int64_t>(128 * 1024)));
+
+  SetPiecePriority(m_fileIndex, 0, p01, PRIO_HIGHER);
+  SetPiecePriority(m_fileIndex, static_cast<size_t>(m_fileSize - p01), p01, PRIO_HIGHER);
+
+  // Set the initial priority for the beginning of the file
+  OnFileAccess(0, 1);
+
+  return true;
+}
+
+bool CMagnetFile::Exists(const CURL& url)
+{
+  struct __stat64 buffer;
+  return Stat(url, &buffer) != -1;
+}
+
+int CMagnetFile::Stat(const CURL& url, struct __stat64* buffer)
+{
+  CMagnetFile magnetFile;
+  if (magnetFile.Open(url))
+    return magnetFile.Stat(buffer);
+
+  // Check if the URL exists as a directory
+  CMagnetDirectory directory;
+  if (directory.Exists(url))
+  {
+    // Set st_mode
+    buffer->st_mode = _S_IFDIR;
+    return 0;
+  }
+
+  return -1;
+}
+
+int CMagnetFile::Stat(struct __stat64* buffer)
+{
+  if (buffer == nullptr)
+    return -1;
+
+  if (m_fileIndex == -1)
+    return -1;
+
+  buffer->st_size = m_fileSize;
+  m_modifiedTime.GetAsTime(buffer->st_mtime);
+
+  return 0;
+}
+
+ssize_t CMagnetFile::Read(void* lpBuf, size_t uiBufSize)
+{
+  CNetworkServices& networkServices = CServiceBroker::GetNetwork().GetServices();
+  CLibtorrent* libtorrent = dynamic_cast<CLibtorrent*>(networkServices.GetLibtorrent());
+  if (libtorrent == nullptr)
+    return -1;
+
+  // Validate state
+  if (!m_torrentHandle.is_valid() || m_fileIndex < 0 || m_fileSize < 0 || m_filePosition < 0)
+    return -1;
+
+  const std::shared_ptr<const lt::torrent_info> torrentInfo = m_torrentHandle.torrent_file();
+  if (!torrentInfo)
+    return -1;
+
+  // Check for EOF
+  if (m_filePosition >= m_fileSize)
+    return 0;
+
+  // Figure out what to read
+  const int64_t readLength =
+      std::min({static_cast<int64_t>(std::numeric_limits<int>::max()),
+                static_cast<int64_t>(uiBufSize), m_fileSize - m_filePosition});
+
+  const lt::peer_request part = torrentInfo->map_file(static_cast<lt::file_index_t>(m_fileIndex),
+                                                      m_filePosition, static_cast<int>(readLength));
+  if (part.start < 0 || part.length < 0)
+    return -1;
+
+  const int partIndex = static_cast<int>(part.piece);
+  const size_t partStart = static_cast<size_t>(part.start);
+  const size_t partLength = static_cast<size_t>(part.length);
+
+  // Update piece priorities
+  OnFileAccess(static_cast<size_t>(m_filePosition), partLength);
+
+  if (!m_torrentHandle.have_piece(part.piece))
+  {
+    if (!libtorrent->WaitForPiece(torrentInfo->info_hashes().v2, static_cast<int>(part.piece)))
+      return -1;
+  }
+
+  const ssize_t readBytes = libtorrent->ReadPiece(m_torrentHandle, partIndex, partStart, partLength,
+                                                  static_cast<uint8_t*>(lpBuf), uiBufSize);
+  if (readBytes > 0)
+    m_filePosition += readBytes;
+
+  return readBytes;
+}
+
+int64_t CMagnetFile::GetPosition()
+{
+  return m_filePosition;
+}
+
+int64_t CMagnetFile::GetLength()
+{
+  return m_fileSize;
+}
+
+int64_t CMagnetFile::Seek(int64_t iFilePosition, int iWhence)
+{
+  switch (iWhence)
+  {
+    case SEEK_SET:
+      m_filePosition = iFilePosition;
+      break;
+    case SEEK_CUR:
+      m_filePosition += iFilePosition;
+      break;
+    case SEEK_END:
+      m_filePosition = m_fileSize + iFilePosition;
+      break;
+    default:
+      return -1;
+  }
+
+  return m_filePosition;
+}
+
+void CMagnetFile::OnFileAccess(size_t fileOffset, size_t partLength)
+{
+  // Set highest priority to the requested range
+  SetPiecePriority(m_fileIndex, static_cast<size_t>(m_filePosition), partLength, PRIO_HIGHEST);
+
+  // Set third highest priority to the next 5% or 64 MiB, whichever is greater
+  const size_t p5 = static_cast<size_t>(std::max(
+      std::min(static_cast<int64_t>(std::numeric_limits<int>::max()), 5 * m_fileSize / 100),
+      static_cast<int64_t>(32 * 1024 * 1024)));
+
+  SetPiecePriority(m_fileIndex, fileOffset, p5, PRIO_HIGH);
+}
+
+void CMagnetFile::SetPiecePriority(int fileIndex,
+                                   size_t fileOffset,
+                                   size_t pieceSize,
+                                   uint8_t priority)
+{
+  const std::shared_ptr<const lt::torrent_info> torrentInfo = m_torrentHandle.torrent_file();
+
+  const lt::file_storage& fileStorage = torrentInfo->files();
+
+  // Make sure offset + size <= file size
+  const int64_t fileSize = fileStorage.file_size(static_cast<lt::file_index_t>(fileIndex));
+  if (fileSize < 0)
+    return;
+
+  fileOffset = std::min(fileOffset, static_cast<size_t>(fileSize));
+
+  // Calculate part size
+  const int64_t partSize =
+      std::min({static_cast<int64_t>(std::numeric_limits<int>::max()),
+                static_cast<int64_t>(pieceSize), static_cast<int64_t>(fileSize - fileOffset)});
+
+  // Map a range in the file into a range in the torrent
+  lt::peer_request part = torrentInfo->map_file(static_cast<lt::file_index_t>(fileIndex),
+                                                fileOffset, static_cast<int>(partSize));
+
+  for (; part.length > 0; part.length -= torrentInfo->piece_size(part.piece++))
+  {
+    if (m_torrentHandle.have_piece(part.piece))
+      continue;
+
+    if (static_cast<uint8_t>(m_torrentHandle.piece_priority(part.piece)) < priority)
+      continue;
+
+    m_torrentHandle.piece_priority(part.piece, static_cast<lt::download_priority_t>(priority));
+  }
+}

--- a/xbmc/filesystem/MagnetFile.h
+++ b/xbmc/filesystem/MagnetFile.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IFile.h"
+#include "XBDateTime.h"
+
+#include <stdint.h>
+#include <string>
+#include <utility>
+
+#include <libtorrent/libtorrent.hpp>
+
+class CURL;
+
+namespace XFILE
+{
+
+class CMagnetFile : public IFile
+{
+public:
+  CMagnetFile() = default;
+  ~CMagnetFile() override = default;
+
+  // Implementation of IFile
+  bool Open(const CURL& url) override;
+  bool Exists(const CURL& url) override;
+  int Stat(const CURL& url, struct __stat64* buffer) override;
+  int Stat(struct __stat64* buffer) override;
+  ssize_t Read(void* lpBuf, size_t uiBufSize) override;
+  int64_t GetPosition() override;
+  int64_t GetLength() override;
+  int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) override;
+  void Close() override {}
+
+private:
+  // Private utility functions
+  void OnFileAccess(size_t fileOffset, size_t partLength);
+  void SetPiecePriority(int fileIndex, size_t fileOffset, size_t pieceSize, uint8_t priority);
+
+  // libtorrent parameters
+  lt::torrent_handle m_torrentHandle;
+
+  // File parameters
+  int m_fileIndex{-1};
+  int64_t m_fileSize{-1};
+  CDateTime m_modifiedTime;
+  int64_t m_filePosition{-1};
+};
+
+} // namespace XFILE

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -20,6 +20,7 @@
 #include "network/EventServer.h"
 #include "network/Network.h"
 #include "network/TCPServer.h"
+#include "network/torrent/ILibtorrent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -78,7 +79,13 @@
 #include "platform/darwin/osx/XBMCHelper.h"
 #endif
 
+#if defined(HAS_LIBTORRENT)
+#include "network/torrent/Libtorrent.h"
+#endif
+
+using namespace KODI;
 using namespace KODI::MESSAGING;
+using namespace NETWORK;
 using namespace JSONRPC;
 using namespace EVENTSERVER;
 #ifdef HAS_UPNP
@@ -90,18 +97,24 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 CNetworkServices::CNetworkServices()
 #ifdef HAS_WEB_SERVER
   : m_webserver(*new CWebServer),
-  m_httpImageHandler(*new CHTTPImageHandler),
-  m_httpImageTransformationHandler(*new CHTTPImageTransformationHandler),
-  m_httpVfsHandler(*new CHTTPVfsHandler),
-  m_httpJsonRpcHandler(*new CHTTPJsonRpcHandler)
+    m_httpImageHandler(*new CHTTPImageHandler),
+    m_httpImageTransformationHandler(*new CHTTPImageTransformationHandler),
+    m_httpVfsHandler(*new CHTTPVfsHandler),
+    m_httpJsonRpcHandler(*new CHTTPJsonRpcHandler)
 #ifdef HAS_WEB_INTERFACE
 #ifdef HAS_PYTHON
-  , m_httpPythonHandler(*new CHTTPPythonHandler)
+    ,
+    m_httpPythonHandler(*new CHTTPPythonHandler)
 #endif
-  , m_httpWebinterfaceHandler(*new CHTTPWebinterfaceHandler)
-  , m_httpWebinterfaceAddonsHandler(*new CHTTPWebinterfaceAddonsHandler)
+    ,
+    m_httpWebinterfaceHandler(*new CHTTPWebinterfaceHandler),
+    m_httpWebinterfaceAddonsHandler(*new CHTTPWebinterfaceAddonsHandler)
 #endif // HAS_WEB_INTERFACE
 #endif // HAS_WEB_SERVER
+#ifdef HAS_LIBTORRENT
+    ,
+    m_libtorrent(std::make_unique<CLibtorrent>())
+#endif
 {
 #ifdef HAS_WEB_SERVER
   m_webserver.RegisterRequestHandler(&m_httpImageHandler);
@@ -139,6 +152,7 @@ CNetworkServices::CNetworkServices()
              CSettings::SETTING_SERVICES_ESALLINTERFACES,
              CSettings::SETTING_SERVICES_ESINITIALDELAY,
              CSettings::SETTING_SERVICES_ESCONTINUOUSDELAY,
+             CSettings::SETTING_SERVICES_KADEMLIA,
              CSettings::SETTING_SMB_WINSSERVER,
              CSettings::SETTING_SMB_WORKGROUP,
              CSettings::SETTING_SMB_MINPROTOCOL,
@@ -489,6 +503,14 @@ bool CNetworkServices::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   }
 #endif // HAS_FILESYSTEM_SMB
 
+  else if (settingId == CSettings::SETTING_SERVICES_KADEMLIA)
+  {
+    if (m_settings->GetBool(CSettings::SETTING_SERVICES_KADEMLIA))
+      return StartLibtorrent();
+    else
+      return StopLibtorrent(false);
+  }
+
   return true;
 }
 
@@ -543,6 +565,8 @@ bool CNetworkServices::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
 
 void CNetworkServices::Start()
 {
+  if (m_settings->GetBool(CSettings::SETTING_SERVICES_KADEMLIA))
+    StartLibtorrent();
   StartZeroconf();
   if (m_settings->GetBool(CSettings::SETTING_SERVICES_UPNP))
     StartUPnP();
@@ -599,6 +623,7 @@ void CNetworkServices::Stop(bool bWait)
   StopAirPlayServer(bWait);
   StopAirTunesServer(bWait);
   StopWSDiscovery();
+  StopLibtorrent(bWait);
 }
 
 bool CNetworkServices::StartServer(enum ESERVERS server, bool start)
@@ -652,6 +677,11 @@ bool CNetworkServices::StartServer(enum ESERVERS server, bool start)
     case ES_WSDISCOVERY:
       // the callback will take care of starting/stopping WS-Discovery
       ret = settings->SetBool(CSettings::SETTING_SERVICES_WSDISCOVERY, start);
+      break;
+
+    case ES_LIBTORRENT:
+      // the callback will take care of starting/stopping libtorrent
+      ret = settings->SetBool(CSettings::SETTING_SERVICES_KADEMLIA, start);
       break;
 
     default:
@@ -1256,6 +1286,51 @@ bool CNetworkServices::StopWSDiscovery()
   return true;
 #endif // HAS_FILESYSTEM_SMB
   return false;
+}
+
+bool CNetworkServices::StartLibtorrent()
+{
+  if (!m_libtorrent)
+    return false;
+
+  if (!m_settings->GetBool(CSettings::SETTING_SERVICES_KADEMLIA))
+    return false;
+
+  if (IsLibtorrentRunning())
+    return true;
+
+  CLog::Log(LOGINFO, "Starting libtorrent");
+  m_libtorrent->Start();
+
+  return true;
+}
+
+bool CNetworkServices::IsLibtorrentRunning() const
+{
+  if (m_libtorrent)
+    return m_libtorrent->IsOnline();
+
+  return false;
+}
+
+bool CNetworkServices::StopLibtorrent(bool bWait)
+{
+  if (!m_libtorrent)
+    return true;
+
+  if (!bWait)
+    CLog::Log(LOGINFO, "Signaling libtorrent to stop");
+  else
+    CLog::Log(LOGINFO, "Stopping libtorrent");
+
+  m_libtorrent->Stop(bWait);
+
+  return true;
+}
+
+ILibtorrent* CNetworkServices::GetLibtorrent()
+{
+  return m_libtorrent.get();
 }
 
 bool CNetworkServices::ValidatePort(int port)

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -10,6 +10,8 @@
 
 #include "settings/lib/ISettingCallback.h"
 
+#include <memory>
+
 class CSettings;
 #ifdef HAS_WEB_SERVER
 class CWebServer;
@@ -26,6 +28,14 @@ class CHTTPWebinterfaceAddonsHandler;
 #endif // HAS_WEB_INTERFACE
 #endif // HAS_WEB_SERVER
 class TiXmlNode;
+
+namespace KODI
+{
+namespace NETWORK
+{
+class ILibtorrent;
+} // namespace NETWORK
+} // namespace KODI
 
 class CNetworkServices : public ISettingCallback
 {
@@ -52,6 +62,7 @@ public:
     ES_EVENTSERVER,
     ES_ZEROCONF,
     ES_WSDISCOVERY,
+    ES_LIBTORRENT,
   };
 
   bool StartServer(enum ESERVERS server, bool start);
@@ -103,6 +114,11 @@ public:
   bool IsWSDiscoveryRunning();
   bool StopWSDiscovery();
 
+  bool StartLibtorrent();
+  bool IsLibtorrentRunning() const;
+  bool StopLibtorrent(bool bWait);
+  KODI::NETWORK::ILibtorrent* GetLibtorrent();
+
 private:
   CNetworkServices(const CNetworkServices&);
   CNetworkServices const& operator=(CNetworkServices const&);
@@ -128,4 +144,6 @@ private:
   CHTTPWebinterfaceAddonsHandler& m_httpWebinterfaceAddonsHandler;
 #endif
 #endif
+
+  std::unique_ptr<KODI::NETWORK::ILibtorrent> m_libtorrent;
 };

--- a/xbmc/network/torrent/CMakeLists.txt
+++ b/xbmc/network/torrent/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(SOURCES TorrentUtils.cpp
+)
+
+set(HEADERS ILibtorrent.h
+            TorrentUtils.h
+)
+
+if (TARGET ${APP_NAME_LC}::Libtorrent)
+  list(APPEND SOURCES Libtorrent.cpp
+                      LibtorrentAlerts.cpp
+                      LibtorrentCache.cpp
+                      TempDiskIO.cpp
+                      TempStorage.cpp
+                      Torrent.cpp
+                      TorrentPiece.cpp
+  )
+  list(APPEND HEADERS ILibtorrentAlertHandler.h
+                      Libtorrent.h
+                      LibtorrentAlerts.h
+                      LibtorrentCache.h
+                      TempDiskIO.h
+                      TempStorage.h
+                      Torrent.h
+                      TorrentPiece.h
+  )
+endif()
+
+core_add_library(network_torrent)

--- a/xbmc/network/torrent/ILibtorrent.h
+++ b/xbmc/network/torrent/ILibtorrent.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2022-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace KODI
+{
+namespace NETWORK
+{
+class ILibtorrent
+{
+public:
+  virtual ~ILibtorrent() = default;
+
+  // Lifecycle functions
+  virtual void Start() = 0;
+  virtual bool IsOnline() const = 0;
+  virtual void Stop(bool bWait) = 0;
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/ILibtorrentAlertHandler.h
+++ b/xbmc/network/torrent/ILibtorrentAlertHandler.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+class ILibtorrentAlertHandler
+{
+public:
+  virtual ~ILibtorrentAlertHandler() = default;
+
+  // Torrent API
+  virtual void OnTorrentError(const lt::sha256_hash& infoHash) = 0;
+
+  // Metadata API
+  virtual void OnMetadataReceived(const lt::sha256_hash& infoHash) = 0;
+  virtual void OnMetadataFailed(const lt::sha256_hash& infoHash) = 0;
+
+  // Piece API
+  virtual void OnPieceFinished(const lt::sha256_hash& infoHash, int pieceIndex) = 0;
+
+  // Read piece API
+  virtual void OnReadPieceFinished(const lt::sha256_hash& infoHash,
+                                   int pieceIndex,
+                                   const uint8_t* pieceBuffer,
+                                   size_t readSize) = 0;
+  virtual void OnReadPieceFailed(const lt::sha256_hash& infoHash, int pieceIndex) = 0;
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/Libtorrent.cpp
+++ b/xbmc/network/torrent/Libtorrent.cpp
@@ -1,0 +1,388 @@
+/*
+ *  Copyright (C) 2022-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Libtorrent.h"
+
+#include "LibtorrentAlerts.h"
+#include "LibtorrentCache.h"
+#include "TempDiskIO.h"
+#include "Torrent.h"
+#include "TorrentPiece.h"
+#include "URL.h"
+#include "filesystem/SpecialProtocol.h"
+#include "utils/StringUtils.h"
+#include "utils/SystemInfo.h"
+#include "utils/log.h"
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+using namespace KODI;
+using namespace NETWORK;
+using namespace std::chrono_literals;
+
+namespace
+{
+// clang-format off
+const std::vector<std::string> LIBTORRENT_DHT_NODES = {
+    "router.bittorrent.com:6881",
+    "router.utorrent.com:6881",
+    "dht.transmissionbt.com:6881",
+};
+// clang-format on
+} // namespace
+
+CLibtorrent::CLibtorrent()
+  : CThread("libtorrent"),
+    m_alerts(std::make_unique<CLibtorrentAlerts>(*this)),
+    m_cache(std::make_unique<CLibtorrentCache>())
+{
+}
+
+CLibtorrent::~CLibtorrent() = default;
+
+void CLibtorrent::Start()
+{
+  if (IsRunning())
+    return;
+
+  lt::session_params sessionParams(lt::default_settings());
+
+  //! @todo Load DHT session state
+
+  //! @todo Implement custom persistent disk IO
+  //sessionParams.disk_io_constructor = CTempDiskIO::CreateTempDisk;
+
+  lt::settings_pack& settings = sessionParams.settings;
+
+  // Set user agent
+  settings.set_str(lt::settings_pack::user_agent, CSysInfo::GetUserAgent());
+
+  // Set DHT bootstrap nodes
+  settings.set_str(lt::settings_pack::dht_bootstrap_nodes,
+                   StringUtils::Join(LIBTORRENT_DHT_NODES, ","));
+
+  // Set alert mask
+  settings.set_int(lt::settings_pack::alert_mask, lt::alert_category::all);
+
+  // Really aggressive settings to optimize time-to-play
+  settings.set_bool(lt::settings_pack::strict_end_game_mode, false);
+  settings.set_bool(lt::settings_pack::announce_to_all_trackers, true);
+  settings.set_bool(lt::settings_pack::announce_to_all_tiers, true);
+  settings.set_int(lt::settings_pack::stop_tracker_timeout, 1);
+  settings.set_int(lt::settings_pack::request_timeout, 2);
+  settings.set_int(lt::settings_pack::whole_pieces_threshold, 5);
+  settings.set_int(lt::settings_pack::request_queue_time, 1);
+  settings.set_int(lt::settings_pack::urlseed_pipeline_size, 2);
+  settings.set_int(lt::settings_pack::urlseed_max_request_bytes, 100 * 1024);
+
+  // Create libtorrent session
+  m_session = std::make_shared<lt::session>(std::move(sessionParams));
+
+  // Create subsystems
+  m_alerts->Start(m_session);
+
+  // Create thread
+  Create(false);
+}
+
+bool CLibtorrent::IsOnline() const
+{
+  return IsRunning();
+}
+
+void CLibtorrent::Stop(bool bWait)
+{
+  StopThread(false);
+
+  m_alerts->Abort();
+
+  // Abort active session
+  if (m_session)
+    m_session->abort();
+
+  // Cancel torrent events
+  for (const auto& torrent : m_torrents)
+    torrent.second->Cancel();
+
+  if (bWait)
+  {
+    // Wait for thread to end
+    StopThread(true);
+
+    // Reset libtorrent state
+    m_session.reset();
+    m_torrents.clear();
+  }
+}
+
+void CLibtorrent::Process()
+{
+  while (!m_bStop)
+    m_alerts->Process();
+}
+
+lt::torrent_handle CLibtorrent::AddTorrent(const std::string& magnetUri)
+{
+  lt::add_torrent_params addTorrentParams;
+  addTorrentParams.save_path = m_cache->GetCachePath();
+  addTorrentParams.flags &= ~lt::torrent_flags::auto_managed;
+  addTorrentParams.flags &= ~lt::torrent_flags::paused;
+
+  lt::error_code errorCode;
+
+  lt::parse_magnet_uri(magnetUri, addTorrentParams, errorCode);
+  if (errorCode)
+  {
+    addTorrentParams.ti = std::make_shared<lt::torrent_info>(magnetUri, errorCode);
+    if (errorCode)
+    {
+      CLog::Log(LOGERROR, "Failed to parse magnet metadata: {}", errorCode.message());
+      return {};
+    }
+  }
+  else
+  {
+    const std::string metadataPath = m_cache->GetMetadataPath(addTorrentParams.info_hashes.v2);
+
+    // Try to read from cache
+    addTorrentParams.ti = std::make_shared<lt::torrent_info>(metadataPath, errorCode);
+
+    if (errorCode)
+    {
+      // The torrent_info is invalid
+      addTorrentParams.ti.reset();
+
+      // Dowload metadata
+      const lt::sha256_hash infoHash = addTorrentParams.info_hashes.v2;
+
+      // Doesn't matter if it's duplicate since we never remove torrents
+      lt::torrent_handle torrentHandle = AddTorrent(addTorrentParams, errorCode);
+      if (errorCode)
+      {
+        CLog::Log(LOGERROR, "Failed to add torrent: {}", errorCode.message());
+        return {};
+      }
+
+      // Wait for metadata to download
+      if (!WaitForMetadata(infoHash))
+      {
+        CLog::Log(LOGERROR, "Failed to download metadata");
+        return {};
+      }
+
+      // Save metadata to cache
+      addTorrentParams.ti = torrentHandle.torrent_file_with_hashes();
+      m_cache->SaveMetadata(addTorrentParams);
+
+      return torrentHandle;
+    }
+  }
+
+  // Doesn't matter if it's a duplicate since we never remove torrents
+  lt::torrent_handle torrentHandle = AddTorrent(addTorrentParams, errorCode);
+  if (errorCode)
+  {
+    CLog::Log(LOGERROR, "Failed to add torrent: {}", errorCode.message());
+    return {};
+  }
+
+  return torrentHandle;
+}
+
+bool CLibtorrent::WaitForMetadata(const lt::sha256_hash& infoHash)
+{
+  std::shared_ptr<CTorrent> torrent = GetTorrent(infoHash);
+
+  if (torrent)
+    return torrent->WaitForMetadata();
+
+  return false;
+}
+
+bool CLibtorrent::WaitForPiece(const lt::sha256_hash& infoHash, int pieceIndex)
+{
+  if (!m_session)
+    return false;
+
+  // Check m_session if piece is already available
+  lt::torrent_handle torrentHandle = m_session->find_torrent(lt::sha1_hash(infoHash));
+  if (torrentHandle.have_piece(static_cast<lt::piece_index_t>(pieceIndex)))
+    return true;
+
+  const std::pair<lt::sha256_hash, int> key = std::make_pair(infoHash, pieceIndex);
+
+  std::shared_ptr<CTorrentPiece> torrentPiece;
+
+  {
+    std::lock_guard<std::mutex> lock(m_piecesMutex);
+
+    auto it = m_waitingPieces.find(key);
+    if (it == m_waitingPieces.end())
+      it = m_waitingPieces.emplace(key, std::make_shared<CTorrentPiece>(infoHash)).first;
+
+    torrentPiece = it->second;
+  }
+
+  while (!torrentHandle.have_piece(static_cast<lt::piece_index_t>(pieceIndex)))
+  {
+    if (torrentPiece->WaitForPiece(1000ms))
+      return true;
+  }
+
+  return torrentHandle.have_piece(static_cast<lt::piece_index_t>(pieceIndex));
+}
+
+ssize_t CLibtorrent::ReadPiece(const lt::torrent_handle& torrentHandle,
+                               int pieceIndex,
+                               size_t partStart,
+                               size_t partLength,
+                               uint8_t* buffer,
+                               size_t bufferSize)
+{
+  // Validate parameters
+  if (pieceIndex < 0)
+    return -1;
+
+  const lt::sha256_hash infoHash = torrentHandle.info_hashes().v2;
+
+  // Create torrent piece with the read buffer
+  const std::shared_ptr<CTorrentPiece> torrentPiece = std::make_shared<CTorrentPiece>(infoHash);
+
+  torrentPiece->SetReadBuffer(buffer, bufferSize, partStart, partLength);
+
+  // Add piece to waiting list
+  {
+    std::lock_guard<std::mutex> lock(m_readingMutex);
+
+    const std::pair<lt::sha256_hash, int> key = std::make_pair(infoHash, pieceIndex);
+
+    auto it = m_readingPieces.find(key);
+    if (it == m_readingPieces.end())
+      it = m_readingPieces.emplace(key, std::vector<std::shared_ptr<CTorrentPiece>>{}).first;
+
+    it->second.push_back(torrentPiece);
+  }
+
+  // Trigger read
+  torrentHandle.read_piece(static_cast<lt::piece_index_t>(pieceIndex));
+
+  // Wait for read to complete
+  if (!torrentPiece->WaitForRead())
+    return -1;
+
+  return torrentPiece->GetReadSize();
+}
+
+void CLibtorrent::OnTorrentError(const lt::sha256_hash& infoHash)
+{
+  OnMetadataFailed(infoHash);
+}
+
+void CLibtorrent::OnMetadataReceived(const lt::sha256_hash& infoHash)
+{
+  std::lock_guard<std::mutex> lock(m_torrentsMutex);
+
+  // Notify the torrent
+  auto it = m_torrents.find(infoHash);
+  if (it != m_torrents.end())
+    it->second->SetMetadataReceived();
+}
+
+void CLibtorrent::OnMetadataFailed(const lt::sha256_hash& infoHash)
+{
+  std::lock_guard<std::mutex> lock(m_torrentsMutex);
+
+  // Notify the torrent
+  auto it = m_torrents.find(infoHash);
+  if (it != m_torrents.end())
+    it->second->SetMetadataFailed();
+}
+
+void CLibtorrent::OnPieceFinished(const lt::sha256_hash& infoHash, int pieceIndex)
+{
+  const std::pair<lt::sha256_hash, int> key = std::make_pair(infoHash, pieceIndex);
+
+  std::lock_guard<std::mutex> lock(m_piecesMutex);
+
+  // Notify the piece
+  auto it = m_waitingPieces.find(key);
+  if (it != m_waitingPieces.end())
+  {
+    it->second->SetPieceFinished();
+    m_waitingPieces.erase(it);
+  }
+}
+
+void CLibtorrent::OnReadPieceFinished(const lt::sha256_hash& infoHash,
+                                      int pieceIndex,
+                                      const uint8_t* pieceBuffer,
+                                      size_t readSize)
+{
+  const std::pair<lt::sha256_hash, int> key = std::make_pair(infoHash, pieceIndex);
+
+  std::lock_guard<std::mutex> lock(m_readingMutex);
+
+  // Notify the pieces
+  auto it = m_readingPieces.find(key);
+  if (it != m_readingPieces.end())
+  {
+    const auto& readingPieces = it->second;
+    for (const std::shared_ptr<CTorrentPiece>& readingPiece : readingPieces)
+      readingPiece->SetReadFinished(pieceBuffer, readSize);
+
+    m_readingPieces.erase(it);
+  }
+}
+
+void CLibtorrent::OnReadPieceFailed(const lt::sha256_hash& infoHash, int pieceIndex)
+{
+  const std::pair<lt::sha256_hash, int> key = std::make_pair(infoHash, pieceIndex);
+
+  std::lock_guard<std::mutex> lock(m_readingMutex);
+
+  // Notify the pieces
+  auto it = m_readingPieces.find(key);
+  if (it != m_readingPieces.end())
+  {
+    const auto& readingPieces = it->second;
+    for (const std::shared_ptr<CTorrentPiece>& readingPiece : readingPieces)
+      readingPiece->SetReadFailed();
+
+    m_readingPieces.erase(it);
+  }
+}
+
+lt::torrent_handle CLibtorrent::AddTorrent(const lt::add_torrent_params& params, lt::error_code& ec)
+{
+  if (m_session)
+  {
+    lt::torrent_handle torrentHandle = m_session->add_torrent(params, ec);
+
+    std::lock_guard<std::mutex> lock(m_torrentsMutex);
+    if (m_torrents.find(params.info_hashes.v2) == m_torrents.end())
+      m_torrents.emplace(params.info_hashes.v2, std::make_shared<CTorrent>(torrentHandle));
+
+    return torrentHandle;
+  }
+
+  ec = lt::errors::invalid_session_handle;
+  return {};
+}
+
+std::shared_ptr<CTorrent> CLibtorrent::GetTorrent(const lt::sha256_hash& infoHash)
+{
+  std::lock_guard<std::mutex> lock(m_torrentsMutex);
+
+  auto it = m_torrents.find(infoHash);
+  if (it != m_torrents.end())
+    return it->second;
+
+  return {};
+}

--- a/xbmc/network/torrent/Libtorrent.h
+++ b/xbmc/network/torrent/Libtorrent.h
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2022-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ILibtorrent.h"
+#include "ILibtorrentAlertHandler.h"
+#include "threads/Thread.h"
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <stddef.h>
+#include <string>
+#include <vector>
+
+#include <libtorrent/libtorrent.hpp>
+
+#include "PlatformDefs.h" // for ssize_t
+
+class CURL;
+
+namespace KODI
+{
+namespace NETWORK
+{
+class CTorrent;
+class CLibtorrentAlerts;
+class CLibtorrentCache;
+class CTorrentPiece;
+
+class CLibtorrent : public ILibtorrent, public ILibtorrentAlertHandler, private CThread
+{
+public:
+  CLibtorrent();
+  ~CLibtorrent() override;
+
+  // Implementation of ILibtorrent
+  void Start() override;
+  bool IsOnline() const override;
+  void Stop(bool bWait) override;
+
+  // Implementation of CThread
+  void Process() override;
+
+  // Libtorrent API
+  lt::torrent_handle AddTorrent(const std::string& magnetUri);
+  bool WaitForMetadata(const lt::sha256_hash& infoHash);
+  bool WaitForPiece(const lt::sha256_hash& infoHash, int pieceIndex);
+  ssize_t ReadPiece(const lt::torrent_handle& torrentHandle,
+                    int pieceIndex,
+                    size_t partStart,
+                    size_t partLength,
+                    uint8_t* buffer,
+                    size_t bufferSize);
+
+  // Implementation of ILibtorrentAlertHandler
+  void OnTorrentError(const lt::sha256_hash& infoHash) override;
+  void OnMetadataReceived(const lt::sha256_hash& infoHash) override;
+  void OnMetadataFailed(const lt::sha256_hash& infoHash) override;
+  void OnPieceFinished(const lt::sha256_hash& infoHash, int pieceIndex) override;
+  void OnReadPieceFinished(const lt::sha256_hash& infoHash,
+                           int pieceIndex,
+                           const uint8_t* pieceBuffer,
+                           size_t readSize) override;
+  void OnReadPieceFailed(const lt::sha256_hash& infoHash, int pieceIndex) override;
+
+private:
+  // Private utility functions
+  lt::torrent_handle AddTorrent(const lt::add_torrent_params& params, lt::error_code& ec);
+  std::shared_ptr<CTorrent> GetTorrent(const lt::sha256_hash& infoHash);
+
+  // libtorrent parameters
+  std::shared_ptr<lt::session> m_session;
+
+  // libtorrent subsystems
+  std::unique_ptr<CLibtorrentAlerts> m_alerts;
+  std::unique_ptr<CLibtorrentCache> m_cache;
+
+  // Torrent parameters
+  std::map<lt::sha256_hash, std::shared_ptr<CTorrent>> m_torrents;
+  std::mutex m_torrentsMutex;
+
+  // Piece parameters
+  std::map<std::pair<lt::sha256_hash, int>, std::shared_ptr<CTorrentPiece>> m_waitingPieces;
+  std::mutex m_piecesMutex;
+
+  // Read piece parameters
+  std::map<std::pair<lt::sha256_hash, int>, std::vector<std::shared_ptr<CTorrentPiece>>>
+      m_readingPieces;
+  std::mutex m_readingMutex;
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/LibtorrentAlerts.cpp
+++ b/xbmc/network/torrent/LibtorrentAlerts.cpp
@@ -1,0 +1,1046 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "LibtorrentAlerts.h"
+
+#include "ILibtorrentAlertHandler.h"
+#include "utils/log.h"
+
+#include <chrono>
+#include <sstream>
+#include <vector>
+
+using namespace KODI;
+using namespace NETWORK;
+using namespace std::chrono_literals;
+
+CLibtorrentAlerts::CLibtorrentAlerts(ILibtorrentAlertHandler& alertHandler)
+  : m_alertHandler(alertHandler)
+{
+}
+
+CLibtorrentAlerts::~CLibtorrentAlerts() = default;
+
+void CLibtorrentAlerts::Start(std::shared_ptr<lt::session> session)
+{
+  m_session = std::move(session);
+  m_running = true;
+}
+
+void CLibtorrentAlerts::Abort()
+{
+  m_running = false;
+}
+
+void CLibtorrentAlerts::Process()
+{
+  while (m_running)
+  {
+    m_session->wait_for_alert(1s);
+
+    std::vector<lt::alert*> alerts;
+
+    // Get all pending requests
+    m_session->pop_alerts(&alerts);
+
+    for (auto* alert : alerts)
+    {
+      // Keep in order found in libtorrent's alert_types.hpp
+      switch (alert->type())
+      {
+        case lt::torrent_removed_alert::alert_type:
+        {
+          // A torrent has been removed
+          auto* a = lt::alert_cast<lt::torrent_removed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent removed: {}",
+                    HashToString(a->info_hashes.v2));
+
+          break;
+        }
+        case lt::read_piece_alert::alert_type:
+        {
+          // The asynchronous read operation initiated by a call to
+          // torrent_handle::read_piece() is completed or has failed
+          auto* a = lt::alert_cast<lt::read_piece_alert>(alert);
+
+          if (a->buffer)
+          {
+            // The read operation succeeded
+            m_alertHandler.OnReadPieceFinished(
+                a->handle.info_hashes().v2, static_cast<int>(a->piece),
+                reinterpret_cast<const uint8_t*>(a->buffer.get()), a->size);
+          }
+          else
+          {
+            // The read failed, the torrent is paused and an error state is set
+            CLog::Log(LOGERROR, LOGLIBTORRENT, "Read failure: {}", a->message());
+            m_alertHandler.OnReadPieceFailed(a->handle.info_hashes().v2,
+                                             static_cast<int>(a->piece));
+          }
+
+          break;
+        }
+        case lt::file_completed_alert::alert_type:
+        {
+          // An individual file completes its download. i.e. all pieces
+          // overlapping this file have passed their hash check
+          auto* a = lt::alert_cast<lt::file_completed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "File completed: {} (file index {})",
+                    HashToString(a->handle.info_hashes().v2), static_cast<int>(a->index));
+
+          break;
+        }
+        case lt::file_renamed_alert::alert_type:
+        {
+          // A call to torrent_handle::rename_file() call has succeeded
+          auto* a = lt::alert_cast<lt::file_renamed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "File renamed: {} (\"{}\" -> \"{}\")",
+                    HashToString(a->handle.info_hashes().v2), a->old_name(), a->new_name());
+
+          break;
+        }
+        case lt::file_rename_failed_alert::alert_type:
+        {
+          // A call to torrent_handle::rename_file() call has failed
+          auto* a = lt::alert_cast<lt::file_rename_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "File renamed failed: {} ({})",
+                    HashToString(a->handle.info_hashes().v2), static_cast<int>(a->index));
+
+          break;
+        }
+        case lt::performance_alert::alert_type:
+        {
+          // A limit is reached that might have a negative impact on upload or
+          // download rate performance
+          auto* a = lt::alert_cast<lt::performance_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Performance alert: {}", a->message());
+
+          break;
+        }
+        case lt::state_changed_alert::alert_type:
+        {
+          // A torrent has changed its state
+          auto* a = lt::alert_cast<lt::state_changed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "State changed: {}", a->message());
+
+          const char* torrentName = a->torrent_name();
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Got torrent name: {}", torrentName);
+
+          break;
+        }
+        case lt::tracker_error_alert::alert_type:
+        {
+          // A tracker error has occurred
+          auto* a = lt::alert_cast<lt::tracker_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Tracker error: {}", a->message());
+
+          break;
+        }
+        case lt::tracker_warning_alert::alert_type:
+        {
+          // A tracker reply contains a warning field. Usually this means that
+          // the tracker announce was successful, but the tracker has a
+          // to the client.
+          auto* a = lt::alert_cast<lt::tracker_warning_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Tracker warning: {}", a->message());
+
+          break;
+        }
+        case lt::scrape_reply_alert::alert_type:
+        {
+          // A scrape request succeeds
+          auto* a = lt::alert_cast<lt::scrape_reply_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Scrape reply: {}", a->message());
+
+          break;
+        }
+        case lt::scrape_failed_alert::alert_type:
+        {
+          // A scrape request has failed. This might be due to the tracker timing
+          // out, refusing connection or returning an http response code
+          // indicating an error.
+          auto* a = lt::alert_cast<lt::scrape_failed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Scraped failed: {}", a->message());
+
+          break;
+        }
+        case lt::tracker_reply_alert::alert_type:
+        {
+          // A tracker announce has succeeded
+          auto* a = lt::alert_cast<lt::tracker_reply_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Tracker reply: {}", a->message());
+
+          break;
+        }
+        case lt::dht_reply_alert::alert_type:
+        {
+          // The DHT receives peers from a node. Typically a few of these alerts
+          // are generated at a time.
+          auto* a = lt::alert_cast<lt::dht_reply_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT reply: {}", a->message());
+
+          break;
+        }
+        case lt::tracker_announce_alert::alert_type:
+        {
+          // A tracker announce has been sent (or attempted to be sent)
+          auto* a = lt::alert_cast<lt::tracker_announce_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Tracker announce: {}", a->message());
+
+          break;
+        }
+        case lt::hash_failed_alert::alert_type:
+        {
+          // A finished piece has failed its hash check
+          auto* a = lt::alert_cast<lt::hash_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Hash failed: {} (piece {})",
+                    HashToString(a->handle.info_hashes().v2), static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::peer_ban_alert::alert_type:
+        {
+          // A peer has been banned because it sent too many corrupt pieces to us
+          auto* a = lt::alert_cast<lt::peer_ban_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer banned: {} ({}:{})",
+                    HashToString(a->handle.info_hashes().v2), a->endpoint.address().to_string(),
+                    a->endpoint.port());
+
+          break;
+        }
+        case lt::peer_unsnubbed_alert::alert_type:
+        {
+          // A peer was unsnubbed. This happens when the peer was snubbed for
+          // stalling sending data, and now it has started sending data again.
+          auto* a = lt::alert_cast<lt::peer_unsnubbed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer unsnubbed: {} ({}:{})",
+                    HashToString(a->handle.info_hashes().v2), a->endpoint.address().to_string(),
+                    a->endpoint.port());
+
+          break;
+        }
+        case lt::peer_snubbed_alert::alert_type:
+        {
+          // A peer was snubbed. This is when a peer stops sending data when we
+          // request it.
+          auto* a = lt::alert_cast<lt::peer_snubbed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer snubbed: {} ({}:{})",
+                    HashToString(a->handle.info_hashes().v2), a->endpoint.address().to_string(),
+                    a->endpoint.port());
+
+          break;
+        }
+        case lt::peer_error_alert::alert_type:
+        {
+          // A peer has sent invalid data over the peer-peer protocol. The peer
+          // will be disconnected, but you get its ip address from the alert
+          // to identify it.
+          auto* a = lt::alert_cast<lt::peer_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Peer error: {}", a->message());
+
+          break;
+        }
+        case lt::peer_connect_alert::alert_type:
+        {
+          // An incoming peer connection has successfully passed the protocol
+          // handshake and is associated with a torrent, or an outgoing peer
+          // connection attempt succeeded.
+          auto* a = lt::alert_cast<lt::peer_connect_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer connected: {}", a->message());
+
+          // If the peer is added to a torrent, the handle member is valid and
+          // the torrent is the torrent it was added to. If the peer is outgoing
+          // and a connection attempt succeeded, the handle is invalid and the
+          // torrent is the one passed to session::connect_peer().
+          if (a->handle.is_valid())
+          {
+            // The peer was added to a torrent
+            CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer connected: {} ({}:{})",
+                      HashToString(a->handle.info_hashes().v2), a->endpoint.address().to_string(),
+                      a->endpoint.port());
+          }
+
+          break;
+        }
+        case lt::peer_disconnected_alert::alert_type:
+        {
+          // A peer is disconnected for any reason (other than the ones covered
+          // by peer_error_alert)
+          auto* a = lt::alert_cast<lt::peer_disconnected_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer disconnected: {}", a->message());
+
+          break;
+        }
+        case lt::invalid_request_alert::alert_type:
+        {
+          // A debug alert that is generated by an incoming invalid piece request
+          auto* a = lt::alert_cast<lt::invalid_request_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Invalid request: {}", a->message());
+
+          break;
+        }
+        case lt::torrent_finished_alert::alert_type:
+        {
+          // The torrent completed downloading and the torrent has switched from
+          // being a downloader to a seed
+          auto* a = lt::alert_cast<lt::torrent_finished_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent finished: {}",
+                    HashToString(a->handle.info_hashes().v2));
+
+          break;
+        }
+        case lt::piece_finished_alert::alert_type:
+        {
+          // A piece just completed downloading and passed its hash check. Note
+          // that torrent_handle::have_piece() could still return false if the
+          // piece is not fully flushed to disk.
+          auto* a = lt::alert_cast<lt::piece_finished_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Piece finished: {} (piece {})",
+                    HashToString(a->handle.info_hashes().v2), static_cast<int>(a->piece_index));
+
+          m_alertHandler.OnPieceFinished(a->handle.info_hashes().v2,
+                                         static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::request_dropped_alert::alert_type:
+        {
+          // A peer has rejected or ignored a piece request
+          auto* a = lt::alert_cast<lt::request_dropped_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Request dropped: {} (block {}, piece {})",
+                    HashToString(a->handle.info_hashes().v2), a->block_index,
+                    static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::block_timeout_alert::alert_type:
+        {
+          // A block request has timed out
+          auto* a = lt::alert_cast<lt::block_timeout_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Block timeout: {} (block {}, piece {})",
+                    HashToString(a->handle.info_hashes().v2), a->block_index,
+                    static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::block_finished_alert::alert_type:
+        {
+          // A block request has received a response
+          auto* a = lt::alert_cast<lt::block_finished_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Block finished: {} (block {}, piece {})",
+                    HashToString(a->handle.info_hashes().v2), a->block_index,
+                    static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::block_downloading_alert::alert_type:
+        {
+          // A block request has been sent to a peer
+          auto* a = lt::alert_cast<lt::block_downloading_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Block downloading: {} (block {}, piece {})",
+                    HashToString(a->handle.info_hashes().v2), a->block_index,
+                    static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::unwanted_block_alert::alert_type:
+        {
+          // A block has been received that was not requested or whose request
+          // timed out
+          auto* a = lt::alert_cast<lt::unwanted_block_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Unwanted block: {} (block {}, piece {})",
+                    HashToString(a->handle.info_hashes().v2), a->block_index,
+                    static_cast<int>(a->piece_index));
+
+          break;
+        }
+        case lt::storage_moved_alert::alert_type:
+        {
+          // All the disk IO has completed and the files have been moved, as an
+          // effect of a call to torrent_handle::move_storage().
+          auto* a = lt::alert_cast<lt::storage_moved_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Storage moved: {} (\"{}\" -> \"{}\")",
+                    HashToString(a->handle.info_hashes().v2), a->old_path(), a->storage_path());
+
+          break;
+        }
+        case lt::storage_moved_failed_alert::alert_type:
+        {
+          // An attempt to move the storage, via torrent_handle::move_storage(), failed
+          auto* a = lt::alert_cast<lt::storage_moved_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Storage move failed: {}", a->message());
+
+          break;
+        }
+        case lt::torrent_deleted_alert::alert_type:
+        {
+          // A request to delete the files of a torrent complete
+          auto* a = lt::alert_cast<lt::torrent_deleted_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent deleted: {}",
+                    HashToString(a->info_hashes.v2));
+
+          break;
+        }
+        case lt::torrent_delete_failed_alert::alert_type:
+        {
+          // A request to delete the files of a torrent failed
+          auto* a = lt::alert_cast<lt::torrent_delete_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Failed to delete torrent: {}", a->message());
+
+          break;
+        }
+        case lt::save_resume_data_alert::alert_type:
+        {
+          // Generated as a response to a torrent_handle::save_resume_data()
+          // request once the disk IO thread is done writing the state for this
+          // torrent
+          auto* a = lt::alert_cast<lt::save_resume_data_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Save resume data: {}", a->message());
+
+          break;
+        }
+        case lt::save_resume_data_failed_alert::alert_type:
+        {
+          // Generated instead of ``save_resume_data_alert`` if there was an error
+          // generating the resume data
+          auto* a = lt::alert_cast<lt::save_resume_data_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Failed to save resume data: {}", a->message());
+
+          break;
+        }
+        case lt::torrent_paused_alert::alert_type:
+        {
+          // Generated as a response to a ``torrent_handle::pause`` request
+          // once all disk IO is complete and the files in the torrent have been
+          // closed. Useful for synchronizing with the disk.
+          auto* a = lt::alert_cast<lt::torrent_paused_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent paused: {}",
+                    HashToString(a->handle.info_hashes().v2));
+
+          break;
+        }
+        case lt::torrent_resumed_alert::alert_type:
+        {
+          // Generated as a response to a torrent_handle::resume() request when
+          // a torrent goes from a paused state to an active state
+          auto* a = lt::alert_cast<lt::torrent_resumed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent resumed: {}",
+                    HashToString(a->handle.info_hashes().v2));
+
+          break;
+        }
+        case lt::torrent_checked_alert::alert_type:
+        {
+          // Posted when a torrent completes checking. i.e. when it transitions
+          // out of the `checking files` state into a state where it is ready to
+          // start downloading
+          auto* a = lt::alert_cast<lt::torrent_checked_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent checked: {}",
+                    HashToString(a->handle.info_hashes().v2));
+
+          break;
+        }
+        case lt::url_seed_alert::alert_type:
+        {
+          // Generated when a HTTP seed name lookup fails
+          auto* a = lt::alert_cast<lt::url_seed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "URL seed error: {}", a->message());
+
+          break;
+        }
+        case lt::file_error_alert::alert_type:
+        {
+          // The storage failed to read or write files that it needed access to,
+          // and the torrent is paused
+          auto* a = lt::alert_cast<lt::file_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "File error: {}", a->message());
+
+          break;
+        }
+        case lt::metadata_failed_alert::alert_type:
+        {
+          // The metadata has been completely received and the info-hash failed
+          // to match it, i.e. the metadata that was received was corrupt
+          auto* a = lt::alert_cast<lt::metadata_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Metadata failed: {}", a->message());
+
+          m_alertHandler.OnMetadataFailed(a->handle.info_hashes().v2);
+
+          break;
+        }
+        case lt::metadata_received_alert::alert_type:
+        {
+          // The metadata has been completely received and the torrent can start
+          // downloading
+          auto* a = lt::alert_cast<lt::metadata_received_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Metadata received: {}",
+                    HashToString(a->handle.info_hashes().v2));
+
+          m_alertHandler.OnMetadataReceived(a->handle.info_hashes().v2);
+
+          break;
+        }
+        case lt::udp_error_alert::alert_type:
+        {
+          // Posted when there is an error on a UDP socket
+          auto* a = lt::alert_cast<lt::udp_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "UDP error: {}", a->message());
+
+          break;
+        }
+        case lt::external_ip_alert::alert_type:
+        {
+          // libtorrent learned about the machine's external IP
+          auto* a = lt::alert_cast<lt::external_ip_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "External IP: {}", a->external_address.to_string());
+
+          break;
+        }
+        case lt::listen_failed_alert::alert_type:
+        {
+          // None of the ports given in the port range to the session can be
+          // opened for listening
+          auto* a = lt::alert_cast<lt::listen_failed_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Listen failed: {}", a->message());
+
+          break;
+        }
+        case lt::listen_succeeded_alert::alert_type:
+        {
+          // The listen port succeeded to be opened on a particular interface
+          auto* a = lt::alert_cast<lt::listen_succeeded_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Listen succeeded: {}", a->message());
+
+          break;
+        }
+        case lt::portmap_error_alert::alert_type:
+        {
+          // A NAT router was successfully found but some part of the port
+          // mapping request failed
+          auto* a = lt::alert_cast<lt::portmap_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Portmap error: {}", a->message());
+
+          break;
+        }
+        case lt::portmap_alert::alert_type:
+        {
+          // A NAT router was successfully found and a port was successfully
+          // mapped on it
+          auto* a = lt::alert_cast<lt::portmap_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Portmap success: {}", a->message());
+
+          break;
+        }
+        case lt::portmap_log_alert::alert_type:
+        {
+          // Generated to log informational events related to either UPnP or
+          // NAT-PMP
+          auto* a = lt::alert_cast<lt::portmap_log_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Portmap log: {}", a->message());
+
+          break;
+        }
+        case lt::fastresume_rejected_alert::alert_type:
+        {
+          // A fast resume file has been passed to add_torrent() but the files on
+          // disk did not match the fast resume file
+          auto* a = lt::alert_cast<lt::fastresume_rejected_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Fastresume rejected: {}", a->message());
+
+          break;
+        }
+        case lt::peer_blocked_alert::alert_type:
+        {
+          // An incoming peer connection, or a peer that's about to be added to
+          // our peer list, is blocked for some reason
+          auto* a = lt::alert_cast<lt::peer_blocked_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer blocked: {}", a->message());
+
+          break;
+        }
+        case lt::dht_announce_alert::alert_type:
+        {
+          // A DHT node announces to an info-hash on our DHT node
+          auto* a = lt::alert_cast<lt::dht_announce_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT announce: {}", a->message());
+
+          break;
+        }
+        case lt::dht_get_peers_alert::alert_type:
+        {
+          // A DHT node sent a `get_peers` message to our DHT node
+          auto* a = lt::alert_cast<lt::dht_get_peers_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT get peers: {}",
+                    HashToString(lt::sha256_hash(a->info_hash)));
+
+          break;
+        }
+        case lt::cache_flushed_alert::alert_type:
+        {
+          // The disk cache has been flushed for a specific torrent as a result
+          // of a call to torrent_handle::flush_cache()
+          auto* a = lt::alert_cast<lt::cache_flushed_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Cache flushed: {}",
+                    HashToString(a->handle.info_hashes().v2));
+
+          break;
+        }
+        case lt::lsd_peer_alert::alert_type:
+        {
+          // We received a local service discovery message from a peer for a
+          // torrent we're currently participating in
+          auto* a = lt::alert_cast<lt::lsd_peer_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "LSD peer: {}", a->message());
+
+          // Log the peer's IP address, port and peer ID
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "LSD peer: {}:{} {}",
+                    a->endpoint.address().to_string(), a->endpoint.port(), a->pid.to_string());
+
+          break;
+        }
+        case lt::trackerid_alert::alert_type:
+        {
+          // A tracker responds with a `trackerid`
+          auto* a = lt::alert_cast<lt::trackerid_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Tracker ID: {}", a->tracker_id());
+
+          break;
+        }
+        case lt::dht_bootstrap_alert::alert_type:
+        {
+          // The initial DHT bootstrap is done
+          auto* a = lt::alert_cast<lt::dht_bootstrap_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT bootstrap done: {}", a->message());
+
+          break;
+        }
+        case lt::torrent_error_alert::alert_type:
+        {
+          // A torrent has been transitioned into the error state
+          auto* a = lt::alert_cast<lt::torrent_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Torrent error: {}", a->message());
+
+          m_alertHandler.OnTorrentError(a->handle.info_hashes().v2);
+
+          break;
+        }
+        case lt::torrent_need_cert_alert::alert_type:
+        {
+          // Always posted for SSL torrents. This is a reminder to the client that
+          // the torrent won't work unless torrent_handle::set_ssl_certificate()
+          // is called with a valid certificate.
+          auto* a = lt::alert_cast<lt::torrent_need_cert_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent need cert: {}", a->message());
+
+          break;
+        }
+        case lt::incoming_connection_alert::alert_type:
+        {
+          // We successfully accepted an incoming connection, through any means
+          auto* a = lt::alert_cast<lt::incoming_connection_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Incoming connection: {}", a->message());
+
+          break;
+        }
+        case lt::add_torrent_alert::alert_type:
+        {
+          // A torrent was attempted to be added and contains the return status
+          // of the add operation
+          auto* a = lt::alert_cast<lt::add_torrent_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent added: {}", a->message());
+
+          break;
+        }
+        case lt::state_update_alert::alert_type:
+        {
+          // Posted when requested by the user, by calling
+          // session::post_torrent_updates() on the session
+          auto* a = lt::alert_cast<lt::state_update_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "State update: {}", a->message());
+
+          break;
+        }
+        case lt::session_stats_alert::alert_type:
+        {
+          // The user requested session statistics by calling
+          // post_session_stats() on the session object
+          auto* a = lt::alert_cast<lt::session_stats_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Session stats: {}", a->message());
+
+          break;
+        }
+        case lt::dht_error_alert::alert_type:
+        {
+          // Something failed in the DHT
+          auto* a = lt::alert_cast<lt::dht_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "DHT error: {}", a->message());
+
+          break;
+        }
+        case lt::dht_immutable_item_alert::alert_type:
+        {
+          // Posted as a response to a call to session::get_item(), specifically
+          // the overload for looking up immutable items in the DHT
+          auto* a = lt::alert_cast<lt::dht_immutable_item_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT immutable item: {}", a->message());
+
+          break;
+        }
+        case lt::dht_mutable_item_alert::alert_type:
+        {
+          // Posted as a response to a call to session::get_item(), specifically
+          // the overload for looking up mutable items in the DHT
+          auto* a = lt::alert_cast<lt::dht_mutable_item_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT mutable item: {}", a->message());
+
+          break;
+        }
+        case lt::dht_put_alert::alert_type:
+        {
+          // A DHT put operation has completed
+          auto* a = lt::alert_cast<lt::dht_put_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT put: {}", a->message());
+
+          break;
+        }
+        case lt::i2p_alert::alert_type:
+        {
+          // Used to report errors in the i2p SAM connection
+          auto* a = lt::alert_cast<lt::i2p_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "I2P error: {}", a->message());
+
+          break;
+        }
+        case lt::dht_outgoing_get_peers_alert::alert_type:
+        {
+          // Generated when we send a get_peers request
+          auto* a = lt::alert_cast<lt::dht_outgoing_get_peers_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT outgoing get peers: {}", a->message());
+
+          break;
+        }
+        case lt::log_alert::alert_type:
+        {
+          // Posted by some session wide event. Its main purpose is
+          // troubleshooting and debugging.
+          auto* a = lt::alert_cast<lt::log_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Log: {}", a->log_message());
+
+          break;
+        }
+        case lt::torrent_log_alert::alert_type:
+        {
+          // Posted by torrent wide events. It's meant to be used for
+          // troubleshooting and debugging.
+          auto* a = lt::alert_cast<lt::torrent_log_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Torrent log: {}", a->log_message());
+
+          break;
+        }
+        case lt::peer_log_alert::alert_type:
+        {
+          // Posted by events specific to a peer. It's meant to be used for
+          // troubleshooting and debugging. Very verbose, so don't log the alert.
+          break;
+        }
+        case lt::lsd_error_alert::alert_type:
+        {
+          // The local service discovery socket failed to start properly
+          auto* a = lt::alert_cast<lt::lsd_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "LSD error: {}", a->message());
+
+          break;
+        }
+        case lt::dht_stats_alert::alert_type:
+        {
+          // Contains current DHT state. Posted in response to
+          // session::post_dht_stats().
+          auto* a = lt::alert_cast<lt::dht_stats_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT stats: {}", a->message());
+
+          break;
+        }
+        case lt::incoming_request_alert::alert_type:
+        {
+          // Posted every time an incoming request from a peer is accepted and
+          // queued up for being serviced
+          auto* a = lt::alert_cast<lt::incoming_request_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Incoming request: {}", a->message());
+
+          break;
+        }
+        case lt::dht_log_alert::alert_type:
+        {
+          // Debug logging of the DHT. Very verbose, so don't log the alert.
+          break;
+        }
+        case lt::dht_pkt_alert::alert_type:
+        {
+          // Posted every time a DHT message is sent or received. Very verbose,
+          // so don't log the alert.
+          break;
+        }
+        case lt::dht_get_peers_reply_alert::alert_type:
+        {
+          // Posted when we receive a response to a DHT get_peers request
+          auto* a = lt::alert_cast<lt::dht_get_peers_reply_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT get peers reply: {}", a->message());
+
+          break;
+        }
+        case lt::dht_direct_response_alert::alert_type:
+        {
+          // Posted exactly once for every call to session_handle::dht_direct_request
+          auto* a = lt::alert_cast<lt::dht_direct_response_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT direct response: {}", a->message());
+
+          break;
+        }
+        case lt::picker_log_alert::alert_type:
+        {
+          // Posted when one or more blocks are picked by the piece picker,
+          // assuming the verbose piece picker logging is enabled
+          auto* a = lt::alert_cast<lt::picker_log_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Picker log: {}", a->message());
+
+          break;
+        }
+        case lt::session_error_alert::alert_type:
+        {
+          // Posted when the session encounters a serious error, potentially fatal
+          auto* a = lt::alert_cast<lt::session_error_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Session error: {}", a->message());
+
+          break;
+        }
+        case lt::dht_live_nodes_alert::alert_type:
+        {
+          // Posted in response to a call to session::dht_live_nodes()
+          auto* a = lt::alert_cast<lt::dht_live_nodes_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT live nodes: {}", a->message());
+
+          break;
+        }
+        case lt::session_stats_header_alert::alert_type:
+        {
+          // Posted the first time post_session_stats() is called
+          auto* a = lt::alert_cast<lt::session_stats_header_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Session stats header: {}", a->message());
+
+          break;
+        }
+        case lt::dht_sample_infohashes_alert::alert_type:
+        {
+          // Posted as a response to a call to session::dht_sample_infohashes()
+          // with the information from the DHT response message
+          auto* a = lt::alert_cast<lt::dht_sample_infohashes_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "DHT sample infohashes: {}", a->message());
+
+          break;
+        }
+        case lt::block_uploaded_alert::alert_type:
+        {
+          // Posted when a block intended to be sent to a peer is placed in the
+          // send buffer
+          auto* a = lt::alert_cast<lt::block_uploaded_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Block uploaded: {}", a->message());
+
+          break;
+        }
+        case lt::alerts_dropped_alert::alert_type:
+        {
+          // Posted to indicate to the client that some alerts were dropped
+          auto* a = lt::alert_cast<lt::alerts_dropped_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Alerts dropped: {}", a->message());
+
+          break;
+        }
+        case lt::socks5_alert::alert_type:
+        {
+          // Posted with SOCKS5 related errors, when a SOCKS5 proxy is configured
+          auto* a = lt::alert_cast<lt::socks5_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "SOCKS5 error: {}", a->message());
+
+          break;
+        }
+        case lt::file_prio_alert::alert_type:
+        {
+          // Posted when a prioritize_files() or file_priority() update of the
+          // file priorities complete, which requires a round-trip to the disk
+          // thread
+          auto* a = lt::alert_cast<lt::file_prio_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "File priority: {}", a->message());
+
+          break;
+        }
+        case lt::oversized_file_alert::alert_type:
+        {
+          // Posted when the initial checking of resume data and files on disk
+          // completes, and a file belonging to the torrent is found on disk but
+          // is larger than the file in the torrent
+          auto* a = lt::alert_cast<lt::oversized_file_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Oversized file: {}", a->message());
+
+          break;
+        }
+        case lt::torrent_conflict_alert::alert_type:
+        {
+          // Posted when two separate torrents (magnet links) resolve to the same
+          // torrent, thus causing the same torrent being added twice
+          auto* a = lt::alert_cast<lt::torrent_conflict_alert>(alert);
+
+          CLog::Log(LOGERROR, LOGLIBTORRENT, "Torrent conflict: {}", a->message());
+
+          break;
+        }
+        case lt::peer_info_alert::alert_type:
+        {
+          // Posted when torrent_handle::post_peer_info() is called
+          auto* a = lt::alert_cast<lt::peer_info_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Peer info: {}", a->message());
+
+          break;
+        }
+        case lt::file_progress_alert::alert_type:
+        {
+          // Posted when torrent_handle::post_file_progress() is called
+          auto* a = lt::alert_cast<lt::file_progress_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "File progress: {}", a->message());
+
+          break;
+        }
+        case lt::piece_info_alert::alert_type:
+        {
+          // Posted when torrent_handle::post_download_queue() is called
+          auto* a = lt::alert_cast<lt::piece_info_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Piece info: {}", a->message());
+
+          break;
+        }
+        case lt::piece_availability_alert::alert_type:
+        {
+          // Posted when torrent_handle::post_piece_availability() is called
+          auto* a = lt::alert_cast<lt::piece_availability_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Piece availability: {}", a->message());
+
+          break;
+        }
+        case lt::tracker_list_alert::alert_type:
+        {
+          // Posted when torrent_handle::post_trackers() is called
+          auto* a = lt::alert_cast<lt::tracker_list_alert>(alert);
+
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Tracker list: {}", a->message());
+
+          break;
+        }
+        default:
+        {
+          CLog::Log(LOGDEBUG, LOGLIBTORRENT, "Unhandled alert: {}", alert->message());
+          break;
+        }
+      }
+    }
+  }
+}
+
+std::string CLibtorrentAlerts::HashToString(const lt::sha256_hash& hash)
+{
+  std::ostringstream ss;
+  ss << hash;
+  return ss.str();
+}

--- a/xbmc/network/torrent/LibtorrentAlerts.h
+++ b/xbmc/network/torrent/LibtorrentAlerts.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ILibtorrent.h"
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+class ILibtorrentAlertHandler;
+
+/*!
+ * \brief Subsystem for handling libtorrent alerts
+ */
+class CLibtorrentAlerts
+{
+public:
+  CLibtorrentAlerts(ILibtorrentAlertHandler& alertHandler);
+  ~CLibtorrentAlerts();
+
+  // Lifecycle functions
+  void Start(std::shared_ptr<lt::session> session);
+  void Process();
+  void Abort();
+
+private:
+  // Utility functions
+  static std::string HashToString(const lt::sha256_hash& hash);
+
+  // Construction parameters
+  ILibtorrentAlertHandler& m_alertHandler;
+
+  // Libtorrent parameters
+  std::shared_ptr<lt::session> m_session;
+
+  // Lifecycle parameters
+  std::atomic<bool> m_running{false};
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/LibtorrentCache.cpp
+++ b/xbmc/network/torrent/LibtorrentCache.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "LibtorrentCache.h"
+
+#include "URL.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <sstream>
+
+using namespace KODI;
+using namespace NETWORK;
+
+CLibtorrentCache::CLibtorrentCache()
+  : m_cachePath(CSpecialProtocol::TranslatePath("special://home/cache/kademlia"))
+{
+  CreatePaths();
+}
+
+std::string CLibtorrentCache::GetMetadataPath(const lt::sha256_hash& infoHash) const
+{
+  std::stringstream str;
+  str << infoHash;
+
+  return URIUtils::AddFileToFolder(m_cachePath, str.str() + ".torrent");
+}
+
+void CLibtorrentCache::SaveMetadata(const lt::add_torrent_params& addTorrentParams)
+{
+  const std::string torrentPath = GetMetadataPath(addTorrentParams.info_hashes.v2);
+
+  // Encode metadata
+  std::vector<char> buffer;
+  try
+  {
+    buffer = lt::write_torrent_file_buf(addTorrentParams, {});
+  }
+  catch (const std::exception& e)
+  {
+    CLog::Log(LOGERROR, "Failed to encode torrent file: {}", e.what());
+    return;
+  }
+
+  // Write metadata to cache
+  XFILE::CFile file;
+  if (!file.OpenForWrite(torrentPath, true))
+  {
+    CLog::Log(LOGERROR, "Failed to open torrent file for writing: {}",
+              CURL::GetRedacted(torrentPath));
+    return;
+  }
+
+  file.Write(buffer.data(), buffer.size());
+}
+
+void CLibtorrentCache::CreatePaths()
+{
+  // Create folder if it doesn't exist
+  if (!XFILE::CDirectory::Exists(m_cachePath))
+  {
+    CLog::Log(LOGDEBUG, "Creating Kademlia cache path: {}", CURL::GetRedacted(m_cachePath));
+    if (!XFILE::CDirectory::Create(m_cachePath))
+      CLog::Log(LOGERROR, "Failed to create Kademlia cache path");
+  }
+}

--- a/xbmc/network/torrent/LibtorrentCache.h
+++ b/xbmc/network/torrent/LibtorrentCache.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+/*!
+ * \brief Subsystem for handling libtorrent caching
+ */
+class CLibtorrentCache
+{
+public:
+  CLibtorrentCache();
+  ~CLibtorrentCache() = default;
+
+  const std::string& GetCachePath() const { return m_cachePath; }
+
+  std::string GetMetadataPath(const lt::sha256_hash& infoHash) const;
+
+  void SaveMetadata(const lt::add_torrent_params& addTorrentParams);
+
+private:
+  void CreatePaths();
+
+  const std::string m_cachePath;
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/TempDiskIO.cpp
+++ b/xbmc/network/torrent/TempDiskIO.cpp
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  This file is derived from the libtorrent project under the BSD 3-clause license.
+ *  Copyright (c) 2017-2018, Steven Siloti
+ *  Copyright (c) 2019-2021, Arvid Norberg
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later AND BSD-3-Clause
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TempDiskIO.h"
+
+#include "TempStorage.h"
+
+using namespace KODI;
+using namespace NETWORK;
+
+CTempDiskIO::CTempDiskIO(lt::io_context& ioc) : m_ioc(ioc)
+{
+}
+
+std::unique_ptr<lt::disk_interface> CTempDiskIO::CreateTempDisk(lt::io_context& ioc,
+                                                                const lt::settings_interface&,
+                                                                lt::counters&)
+{
+  return std::make_unique<CTempDiskIO>(ioc);
+}
+
+lt::storage_holder CTempDiskIO::new_torrent(const lt::storage_params& params,
+                                            const std::shared_ptr<void>&)
+{
+  const lt::storage_index_t idx =
+      m_freeSlots.empty() ? m_torrents.end_index() : PopSlot(m_freeSlots);
+
+  auto storage = std::make_unique<CTempStorage>(params.files);
+
+  if (idx == m_torrents.end_index())
+    m_torrents.emplace_back(std::move(storage));
+  else
+    m_torrents[idx] = std::move(storage);
+
+  return lt::storage_holder(idx, *this);
+}
+
+void CTempDiskIO::remove_torrent(const lt::storage_index_t idx)
+{
+  m_torrents[idx].reset();
+  m_freeSlots.push_back(idx);
+}
+
+void CTempDiskIO::async_read(
+    lt::storage_index_t storage,
+    const lt::peer_request& r,
+    std::function<void(lt::disk_buffer_holder block, const lt::storage_error& se)> handler,
+    lt::disk_job_flags_t)
+{
+  // This buffer is owned by the storage. It will remain valid for as
+  // long as the torrent remains in the session. We don't need any lifetime
+  // management of it.
+  lt::storage_error error;
+  lt::span<const char> b = m_torrents[storage]->Read(r, error);
+
+  post(m_ioc,
+       [handler, error, b, this]
+       {
+         handler(
+             lt::disk_buffer_holder(*this, const_cast<char*>(b.data()), static_cast<int>(b.size())),
+             error);
+       });
+}
+
+bool CTempDiskIO::async_write(lt::storage_index_t storage,
+                              const lt::peer_request& r,
+                              const char* buf,
+                              std::shared_ptr<lt::disk_observer>,
+                              std::function<void(const lt::storage_error&)> handler,
+                              lt::disk_job_flags_t)
+{
+  lt::span<const char> const b = {buf, r.length};
+
+  m_torrents[storage]->Write(b, r.piece, r.start);
+
+  post(m_ioc, [=] { handler(lt::storage_error()); });
+
+  return false;
+}
+
+void CTempDiskIO::async_hash(
+    lt::storage_index_t storage,
+    const lt::piece_index_t piece,
+    lt::span<lt::sha256_hash> blockHashes,
+    lt::disk_job_flags_t,
+    std::function<void(lt::piece_index_t, const lt::sha1_hash&, const lt::storage_error&)> handler)
+{
+  lt::storage_error error;
+
+  const lt::sha256_hash hash = m_torrents[storage]->Hash(piece, blockHashes, error);
+
+  post(m_ioc, [=] { handler(piece, lt::sha1_hash(hash), error); });
+}
+
+void CTempDiskIO::async_hash2(
+    lt::storage_index_t storage,
+    const lt::piece_index_t piece,
+    const int offset,
+    lt::disk_job_flags_t,
+    std::function<void(lt::piece_index_t, const lt::sha256_hash&, const lt::storage_error&)>
+        handler)
+{
+  lt::storage_error error;
+
+  const lt::sha256_hash hash = m_torrents[storage]->Hash2(piece, offset, error);
+
+  post(m_ioc, [=] { handler(piece, hash, error); });
+}
+
+void CTempDiskIO::async_move_storage(
+    lt::storage_index_t,
+    std::string p,
+    lt::move_flags_t,
+    std::function<void(lt::status_t, const std::string&, const lt::storage_error&)> handler)
+
+{
+  post(m_ioc,
+       [=]
+       {
+         handler(lt::disk_status::fatal_disk_error, p,
+                 lt::storage_error(lt::error_code(boost::system::errc::operation_not_supported,
+                                                  lt::system_category())));
+       });
+}
+
+void CTempDiskIO::async_check_files(
+    lt::storage_index_t,
+    const lt::add_torrent_params*,
+    lt::aux::vector<std::string, lt::file_index_t>,
+    std::function<void(lt::status_t, const lt::storage_error&)> handler)
+{
+  post(m_ioc, [=] { handler(lt::status_t{}, lt::storage_error()); });
+}
+
+void CTempDiskIO::async_stop_torrent(lt::storage_index_t, std::function<void()> handler)
+{
+  post(m_ioc, handler);
+}
+
+void CTempDiskIO::async_rename_file(
+    lt::storage_index_t,
+    const lt::file_index_t idx,
+    const std::string name,
+    std::function<void(const std::string&, lt::file_index_t, const lt::storage_error&)> handler)
+
+{
+  post(m_ioc, [=] { handler(name, idx, lt::storage_error()); });
+}
+
+void CTempDiskIO::async_delete_files(lt::storage_index_t,
+                                     lt::remove_flags_t,
+                                     std::function<void(const lt::storage_error&)> handler)
+{
+  post(m_ioc, [=] { handler(lt::storage_error()); });
+}
+
+void CTempDiskIO::async_set_file_priority(
+    lt::storage_index_t,
+    lt::aux::vector<lt::download_priority_t, lt::file_index_t> prio,
+    std::function<void(const lt::storage_error&,
+                       lt::aux::vector<lt::download_priority_t, lt::file_index_t>)> handler)
+
+{
+  post(m_ioc,
+       [=]
+       {
+         handler(lt::storage_error(lt::error_code(boost::system::errc::operation_not_supported,
+                                                  lt::system_category())),
+                 prio);
+       });
+}
+
+void CTempDiskIO::async_clear_piece(lt::storage_index_t,
+                                    lt::piece_index_t index,
+                                    std::function<void(lt::piece_index_t)> handler)
+{
+  post(m_ioc, [=] { handler(index); });
+}
+
+std::vector<lt::open_file_state> CTempDiskIO::get_status(lt::storage_index_t) const
+{
+  return {};
+}
+
+void CTempDiskIO::free_disk_buffer(char*)
+{
+  // Never free any buffer. We only return buffers owned by the storage
+  // object.
+}
+
+lt::storage_index_t CTempDiskIO::PopSlot(std::vector<lt::storage_index_t>& queue)
+{
+  TORRENT_ASSERT(!queue.empty());
+
+  lt::storage_index_t const ret = queue.back();
+  queue.pop_back();
+
+  return ret;
+}

--- a/xbmc/network/torrent/TempDiskIO.h
+++ b/xbmc/network/torrent/TempDiskIO.h
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  This file is derived from the libtorrent project under the BSD 3-clause license.
+ *  Copyright (c) 2017-2018, Steven Siloti
+ *  Copyright (c) 2019-2021, Arvid Norberg
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later AND BSD-3-Clause
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+
+class CTempStorage;
+
+struct CTempDiskIO final : lt::disk_interface, lt::buffer_allocator_interface
+{
+public:
+  explicit CTempDiskIO(lt::io_context& ioc);
+
+  static std::unique_ptr<lt::disk_interface> CreateTempDisk(lt::io_context& ioc,
+                                                            const lt::settings_interface&,
+                                                            lt::counters&);
+
+  // Implementation of lt::disk_interface
+  lt::storage_holder new_torrent(const lt::storage_params& params,
+                                 const std::shared_ptr<void>&) override;
+  void remove_torrent(const lt::storage_index_t idx) override;
+  void async_read(
+      lt::storage_index_t storage,
+      const lt::peer_request& r,
+      std::function<void(lt::disk_buffer_holder block, const lt::storage_error& se)> handler,
+      lt::disk_job_flags_t) override;
+  bool async_write(lt::storage_index_t storage,
+                   const lt::peer_request& r,
+                   const char* buf,
+                   std::shared_ptr<lt::disk_observer>,
+                   std::function<void(const lt::storage_error&)> handler,
+                   lt::disk_job_flags_t) override;
+  void async_hash(
+      lt::storage_index_t storage,
+      const lt::piece_index_t piece,
+      lt::span<lt::sha256_hash> blockHashes,
+      lt::disk_job_flags_t,
+      std::function<void(lt::piece_index_t, const lt::sha1_hash&, const lt::storage_error&)>
+          handler) override;
+  void async_hash2(
+      lt::storage_index_t storage,
+      const lt::piece_index_t piece,
+      const int offset,
+      lt::disk_job_flags_t,
+      std::function<void(lt::piece_index_t, const lt::sha256_hash&, const lt::storage_error&)>
+          handler) override;
+  void async_move_storage(
+      lt::storage_index_t,
+      std::string p,
+      lt::move_flags_t,
+      std::function<void(lt::status_t, const std::string&, const lt::storage_error&)> handler)
+      override;
+  void async_release_files(lt::storage_index_t, std::function<void()>) override {}
+  void async_check_files(
+      lt::storage_index_t,
+      const lt::add_torrent_params*,
+      lt::aux::vector<std::string, lt::file_index_t>,
+      std::function<void(lt::status_t, const lt::storage_error&)> handler) override;
+  void async_stop_torrent(lt::storage_index_t, std::function<void()> handler) override;
+  void async_rename_file(
+      lt::storage_index_t,
+      const lt::file_index_t idx,
+      const std::string name,
+      std::function<void(const std::string&, lt::file_index_t, const lt::storage_error&)> handler)
+      override;
+  void async_delete_files(lt::storage_index_t,
+                          lt::remove_flags_t,
+                          std::function<void(const lt::storage_error&)> handler) override;
+  void async_set_file_priority(
+      lt::storage_index_t,
+      lt::aux::vector<lt::download_priority_t, lt::file_index_t> prio,
+      std::function<void(const lt::storage_error&,
+                         lt::aux::vector<lt::download_priority_t, lt::file_index_t>)> handler)
+      override;
+  void async_clear_piece(lt::storage_index_t,
+                         lt::piece_index_t index,
+                         std::function<void(lt::piece_index_t)> handler) override;
+  void update_stats_counters(lt::counters&) const override {}
+  std::vector<lt::open_file_state> get_status(lt::storage_index_t) const override;
+  void abort(bool) override {}
+  void submit_jobs() override {}
+  void settings_updated() override {}
+
+  // Implementation of lt::buffer_allocator_interface
+  void free_disk_buffer(char*) override;
+
+private:
+  // Utility functions
+  static lt::storage_index_t PopSlot(std::vector<lt::storage_index_t>& queue);
+
+  // Callbacks are posted on this
+  lt::io_context& m_ioc;
+
+  // Storage for torrents
+  lt::aux::vector<std::shared_ptr<CTempStorage>, lt::storage_index_t> m_torrents;
+
+  // Slots that are unused in the m_torrents vector
+  std::vector<lt::storage_index_t> m_freeSlots;
+};
+
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/TempStorage.cpp
+++ b/xbmc/network/torrent/TempStorage.cpp
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  This file is derived from the libtorrent project under the BSD 3-clause license.
+ *  Copyright (c) 2017-2018, Steven Siloti
+ *  Copyright (c) 2019-2021, Arvid Norberg
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later AND BSD-3-Clause
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TempStorage.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include <boost/asio/error.hpp>
+
+using namespace KODI;
+using namespace NETWORK;
+
+CTempStorage::CTempStorage(const lt::file_storage& fs) : m_files(fs)
+{
+}
+
+lt::span<const char> CTempStorage::Read(const lt::peer_request r, lt::storage_error& ec) const
+{
+  const auto it = m_fileData.find(r.piece);
+
+  if (it == m_fileData.end())
+  {
+    ec.operation = lt::operation_t::file_read;
+    ec.ec = boost::asio::error::eof;
+    return {};
+  }
+
+  if (static_cast<int>(it->second.size()) <= r.start)
+  {
+    ec.operation = lt::operation_t::file_read;
+    ec.ec = boost::asio::error::eof;
+    return {};
+  }
+
+  return {it->second.data() + r.start,
+          std::min(r.length, static_cast<int>(it->second.size()) - r.start)};
+}
+
+void CTempStorage::Write(const lt::span<const char> b,
+                         const lt::piece_index_t piece,
+                         const int offset)
+{
+  auto& data = m_fileData[piece];
+
+  if (data.empty())
+  {
+    // Allocate the whole piece, otherwise we'll invalidate the pointers
+    // we have returned back to libtorrent
+    const int size = GetPieceSize(piece);
+    data.resize(std::size_t(size));
+  }
+
+  TORRENT_ASSERT(offset + b.size() <= static_cast<int>(data.size()));
+
+  std::memcpy(data.data() + offset, b.data(), std::size_t(b.size()));
+}
+
+lt::sha256_hash CTempStorage::Hash(const lt::piece_index_t piece,
+                                   const lt::span<lt::sha256_hash> blockHashes,
+                                   lt::storage_error& ec) const
+{
+  const auto it = m_fileData.find(piece);
+
+  if (it == m_fileData.end())
+  {
+    ec.operation = lt::operation_t::file_read;
+    ec.ec = boost::asio::error::eof;
+    return {};
+  }
+
+  if (!blockHashes.empty())
+  {
+    const int pieceSize2 = m_files.piece_size2(piece);
+    const int blocksInPiece2 = m_files.blocks_in_piece2(piece);
+    const char* buf = it->second.data();
+    std::int64_t offset = 0;
+
+    for (int k = 0; k < blocksInPiece2; ++k)
+    {
+      lt::hasher256 h2;
+      const std::ptrdiff_t len2 =
+          std::min(lt::default_block_size, static_cast<int>(pieceSize2 - offset));
+      h2.update({buf, len2});
+      buf += len2;
+      offset += len2;
+      blockHashes[k] = h2.final();
+    }
+  }
+
+  return lt::hasher256(it->second).final();
+}
+
+lt::sha256_hash CTempStorage::Hash2(const lt::piece_index_t piece,
+                                    const int offset,
+                                    lt::storage_error& ec)
+{
+  const auto it = m_fileData.find(piece);
+  if (it == m_fileData.end())
+  {
+    ec.operation = lt::operation_t::file_read;
+    ec.ec = boost::asio::error::eof;
+    return {};
+  }
+
+  const int pieceSize = m_files.piece_size2(piece);
+
+  const std::ptrdiff_t length = std::min(lt::default_block_size, pieceSize - offset);
+
+  lt::span<const char> b = {it->second.data() + offset, length};
+  return lt::hasher256(b).final();
+}
+
+int CTempStorage::GetPieceSize(lt::piece_index_t piece) const
+{
+  const int num_pieces = static_cast<int>((m_files.total_size() + m_files.piece_length() - 1) /
+                                          m_files.piece_length());
+
+  return static_cast<int>(piece) < num_pieces - 1
+             ? m_files.piece_length()
+             : static_cast<int>(m_files.total_size() -
+                                std::int64_t(num_pieces - 1) * m_files.piece_length());
+}

--- a/xbmc/network/torrent/TempStorage.h
+++ b/xbmc/network/torrent/TempStorage.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  This file is derived from the libtorrent project under the BSD 3-clause license.
+ *  Copyright (c) 2017-2018, Steven Siloti
+ *  Copyright (c) 2019-2021, Arvid Norberg
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later AND BSD-3-Clause
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+
+class CTempStorage
+{
+public:
+  explicit CTempStorage(const lt::file_storage& fs);
+
+  lt::span<const char> Read(const lt::peer_request r, lt::storage_error& ec) const;
+
+  void Write(const lt::span<const char> b, const lt::piece_index_t piece, const int offset);
+
+  lt::sha256_hash Hash(const lt::piece_index_t piece,
+                       const lt::span<lt::sha256_hash> blockHashes,
+                       lt::storage_error& ec) const;
+
+  lt::sha256_hash Hash2(const lt::piece_index_t piece, const int offset, lt::storage_error& ec);
+
+private:
+  // Utility functions
+  int GetPieceSize(lt::piece_index_t piece) const;
+
+  // Construction parameters
+  const lt::file_storage& m_files;
+
+  // Storage
+  std::map<lt::piece_index_t, std::vector<char>> m_fileData;
+};
+
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/Torrent.cpp
+++ b/xbmc/network/torrent/Torrent.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Torrent.h"
+
+using namespace KODI;
+using namespace NETWORK;
+
+CTorrent::CTorrent(lt::torrent_handle torrentHandle) : m_torrentHandle(std::move(torrentHandle))
+{
+}
+
+void CTorrent::Cancel()
+{
+  m_metadataEvent.Set();
+}
+
+bool CTorrent::WaitForMetadata()
+{
+  // Wait for metadata to be received or fail
+  while (!m_metadataReceived && !m_metadataFailed)
+    m_metadataEvent.Wait();
+
+  return m_metadataReceived;
+}
+
+void CTorrent::SetMetadataReceived()
+{
+  m_metadataReceived = true;
+  m_metadataEvent.Set();
+}
+
+void CTorrent::SetMetadataFailed()
+{
+  m_metadataFailed = true;
+  m_metadataEvent.Set();
+}

--- a/xbmc/network/torrent/Torrent.h
+++ b/xbmc/network/torrent/Torrent.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/Event.h"
+
+#include <mutex>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+class CTorrent
+{
+public:
+  CTorrent(lt::torrent_handle torrentHandle);
+  ~CTorrent() = default;
+
+  // Torrent API
+  void Cancel();
+
+  // Metadata API
+  bool WaitForMetadata();
+  void SetMetadataReceived();
+  void SetMetadataFailed();
+
+private:
+  // Construction parameters
+  const lt::torrent_handle m_torrentHandle;
+
+  // Metadata parameters
+  bool m_metadataReceived = false;
+  bool m_metadataFailed = false;
+  std::mutex m_metadataMutex;
+  CEvent m_metadataEvent;
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/TorrentPiece.cpp
+++ b/xbmc/network/torrent/TorrentPiece.cpp
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TorrentPiece.h"
+
+#include <cstring>
+
+using namespace KODI;
+using namespace NETWORK;
+
+CTorrentPiece::CTorrentPiece(const lt::sha256_hash& infoHash) : m_infoHash(infoHash)
+{
+}
+
+void CTorrentPiece::Cancel()
+{
+  m_pieceEvent.Set();
+  m_readEvent.Set();
+}
+
+bool CTorrentPiece::WaitForPiece(std::chrono::milliseconds timeout)
+{
+  // Wait for piece to be received
+  if (!m_pieceFinished)
+    m_pieceEvent.Wait(timeout);
+
+  return m_pieceFinished;
+}
+
+void CTorrentPiece::SetPieceFinished()
+{
+  m_pieceFinished = true;
+  m_pieceEvent.Set();
+}
+
+void CTorrentPiece::SetReadBuffer(uint8_t* readBuffer,
+                                  size_t bufferSize,
+                                  size_t partStart,
+                                  size_t partLength)
+{
+  // Set read piece parameters
+  m_readBuffer = readBuffer;
+  m_bufferSize = bufferSize;
+  m_partStart = partStart;
+  m_partLength = partLength;
+  m_readSize = -1;
+}
+
+bool CTorrentPiece::WaitForRead()
+{
+  // Wait for read to be performed or fail
+  if (!m_readFinished && !m_readFailed)
+    m_readEvent.Wait();
+
+  return m_readFinished;
+}
+
+void CTorrentPiece::SetReadFinished(const uint8_t* pieceBuffer, size_t readSize)
+{
+  m_readFinished = true;
+
+  // Validate state
+  if (m_readBuffer == nullptr || m_bufferSize == 0)
+    return;
+
+  // Calculate read length
+  const int readLength = std::min({static_cast<int>(readSize) - static_cast<int>(m_partStart),
+                                   static_cast<int>(m_bufferSize), static_cast<int>(m_partLength)});
+  if (readLength < 0)
+    return;
+
+  // Copy from libtorrent buffer to our buffer
+  std::memcpy(m_readBuffer, pieceBuffer + m_partStart, static_cast<size_t>(readLength));
+
+  // Record read size
+  m_readSize = static_cast<ssize_t>(readLength);
+
+  m_readEvent.Set();
+}
+
+void CTorrentPiece::SetReadFailed()
+{
+  m_readFailed = true;
+  m_readEvent.Set();
+}

--- a/xbmc/network/torrent/TorrentPiece.h
+++ b/xbmc/network/torrent/TorrentPiece.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/Event.h"
+
+#include <chrono>
+#include <stdint.h>
+
+#include <libtorrent/libtorrent.hpp>
+
+namespace KODI
+{
+namespace NETWORK
+{
+class CTorrentPiece
+{
+public:
+  CTorrentPiece(const lt::sha256_hash& infoHash);
+  ~CTorrentPiece() = default;
+
+  // Torrent API
+  void Cancel();
+
+  // Piece API
+  bool IsPieceFinished() const { return m_pieceFinished; }
+  bool WaitForPiece(std::chrono::milliseconds timeout);
+  void SetPieceFinished();
+
+  // Read piece API
+  void SetReadBuffer(uint8_t* readBuffer, size_t bufferSize, size_t partStart, size_t partLength);
+  bool IsReadFinished() const { return m_readFinished; }
+  bool IsReadFailed() const { return m_readFailed; }
+  bool WaitForRead();
+  void SetReadFinished(const uint8_t* pieceBuffer, size_t pieceSize);
+  void SetReadFailed();
+  ssize_t GetReadSize() const { return m_readSize; }
+
+private:
+  // Construction parameters
+  const lt::sha256_hash m_infoHash;
+
+  // Piece parameters
+  bool m_pieceFinished{false};
+  CEvent m_pieceEvent;
+
+  // Read piece parameters
+  bool m_readFinished{false};
+  bool m_readFailed{false};
+  uint8_t* m_readBuffer{nullptr};
+  size_t m_bufferSize{0};
+  size_t m_partStart{0};
+  size_t m_partLength{0};
+  ssize_t m_readSize{-1};
+  CEvent m_readEvent;
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/TorrentUtils.cpp
+++ b/xbmc/network/torrent/TorrentUtils.cpp
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TorrentUtils.h"
+
+#include "URL.h"
+#include "utils/StringUtils.h"
+
+using namespace KODI;
+using namespace NETWORK;
+
+std::pair<std::string, std::string> CTorrentUtils::SplitMagnetURL(const CURL& url)
+{
+  std::string filename = url.GetFileName();
+
+  CURL urlCopy(url);
+  urlCopy.SetFileName("");
+  std::string magnetUri = urlCopy.Get();
+
+  // Remove any protocol slashes from the magnet URI
+  if (StringUtils::StartsWith(magnetUri, "magnet://"))
+    magnetUri.erase(std::strlen("magnet:"), 2);
+
+  return std::make_pair(magnetUri, filename);
+}

--- a/xbmc/network/torrent/TorrentUtils.h
+++ b/xbmc/network/torrent/TorrentUtils.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+class CURL;
+
+namespace KODI
+{
+namespace NETWORK
+{
+class CTorrentUtils
+{
+public:
+  /*!
+   * \brief Split a magnet URL, returning its original URI and the
+   *        file/directory inside the torrent
+   *
+   * For example, the following URL will be split into the following parts:
+   *
+   *   magnet://Big%20Buck%20Bunny.mp4?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big%20Buck%20Bunny
+   *
+   * Magnet URI: magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big%20Buck%20Bunny
+   * Filename: Big Buck Bunny.mp4
+   *
+   * \param url The magnet URL, possibly containing an optional 
+   *            inside the torrent
+   *
+   * \return A pair containing the magnet URI and the file/directory inside the
+   *         torrent
+   */
+  static std::pair<std::string, std::string> SplitMagnetURL(const CURL& url);
+};
+} // namespace NETWORK
+} // namespace KODI

--- a/xbmc/network/torrent/test/CMakeLists.txt
+++ b/xbmc/network/torrent/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(TARGET ${APP_NAME_LC}::Libtorrent)
+  set(SOURCES TestLibtorrent.cpp)
+
+  core_add_test_library(torrent_test)
+endif()

--- a/xbmc/network/torrent/test/TestLibtorrent.cpp
+++ b/xbmc/network/torrent/test/TestLibtorrent.cpp
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "network/torrent/Libtorrent.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace NETWORK;
+
+constexpr const char* TEST_MAGNET_LINK =
+    "magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big%20Buck%20Bunny";
+
+class TestLibtorrent : public testing::Test
+{
+protected:
+  void SetUp() override { libtorrent.Start(); }
+
+  void TearDown() override
+  {
+    libtorrent.Stop(false);
+    libtorrent.Stop(true);
+  }
+
+  CLibtorrent libtorrent;
+};
+
+TEST_F(TestLibtorrent, IsOnline)
+{
+  ASSERT_TRUE(libtorrent.IsOnline());
+}
+
+TEST_F(TestLibtorrent, DISABLED_AddTorrent)
+{
+  //! @todo: We might need to wait until the DHT is fully bootstrapped before
+  //! we can add a torrent
+  lt::torrent_handle torrentHandle = libtorrent.AddTorrent(TEST_MAGNET_LINK);
+  ASSERT_TRUE(torrentHandle.is_valid());
+}

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -440,6 +440,10 @@ void CSettingConditions::Initialize()
   m_simpleConditions.emplace("has_xbmchelper");
 #endif
 
+#ifdef HAS_LIBTORRENT
+  m_simpleConditions.insert("has_libtorrent");
+#endif
+
   // add complex conditions
   m_complexConditions.emplace("addonhassettings", AddonHasSettings);
   m_complexConditions.emplace("checkmasterlock", CheckMasterLock);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -358,6 +358,7 @@ public:
   static constexpr auto SETTING_SERVICES_USEAIRPLAYPASSWORD = "services.useairplaypassword";
   static constexpr auto SETTING_SERVICES_AIRPLAYPASSWORD = "services.airplaypassword";
   static constexpr auto SETTING_SERVICES_AIRPLAYVIDEOSUPPORT = "services.airplayvideosupport";
+  static constexpr auto SETTING_SERVICES_KADEMLIA = "services.kademlia";
   static constexpr auto SETTING_SMB_WINSSERVER = "smb.winsserver";
   static constexpr auto SETTING_SMB_WORKGROUP = "smb.workgroup";
   static constexpr auto SETTING_SMB_MINPROTOCOL = "smb.minprotocol";

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1360,6 +1360,16 @@ bool URIUtils::IsDOSPath(const std::string &path)
   return false;
 }
 
+bool URIUtils::IsURN(const std::string& strFile)
+{
+  return IsMagnetURI(strFile);
+}
+
+bool URIUtils::IsMagnetURI(const std::string& strFile)
+{
+  return StringUtils::StartsWithNoCase(strFile, "magnet:");
+}
+
 std::string URIUtils::AppendSlash(std::string strFolder)
 {
   AddSlashAtEnd(strFolder);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -256,6 +256,8 @@ public:
   static bool IsPVRRadioChannel(const std::string& strFile);
   static bool IsPVRChannelGroup(const std::string& strFile);
   static bool IsPVRGuideItem(const std::string& strFile);
+  static bool IsURN(const std::string& strFile);
+  static bool IsMagnetURI(const std::string& strFile);
 
   static std::string AppendSlash(std::string strFolder);
   static void AddSlashAtEnd(std::string& strFolder);

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -229,6 +229,10 @@ void CLog::SettingOptionsLoggingComponentsFiller(const SettingConstPtr& setting,
 #if defined(HAS_FILESYSTEM_SMB)
   list.emplace_back(g_localizeStrings.Get(37050), LOGWSDISCOVERY);
 #endif
+#if defined(HAS_LIBTORRENT)
+  list.emplace_back(g_localizeStrings.Get(21353),
+                    LOGLIBTORRENT); // Verbose logging for [B]libtorrent[/B]
+#endif
 }
 
 Logger CLog::GetLogger(const std::string& loggerName)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1959,7 +1959,8 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
     CFileItemPtr pItem = m_vecItems->Get(index);
     // if the item is a folder we need to copy the path of
     // the filtered item to be able to keep the applied filters
-    if (pItem->m_bIsFolder)
+    // except for magnet links which depend on specific options
+    if (pItem->m_bIsFolder && !URIUtils::IsMagnetURI(pItem->GetPath()))
     {
       CURL itemUrl(pItem->GetPath());
       if (!filterOption.empty())


### PR DESCRIPTION
## Summary
- fix the build target names in `FindLibdatachannel.cmake`
- fix the build target names in `FindLibtorrent.cmake`
- avoid re-creating build targets when modules are found more than once

## Testing
- `cmake .. -DAPP_RENDER_SYSTEM=gl` *(fails: Could NOT find UDEV)*

------
https://chatgpt.com/codex/tasks/task_e_683e5734b3088326b344925887604ddf