### PR TITLE
[Android] Safeguard joystick motion events

### DIFF
--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -366,6 +366,13 @@ bool CAndroidJoystickState::ProcessEvent(const AInputEvent* event)
     case AINPUT_EVENT_TYPE_MOTION:
     {
       size_t count = AMotionEvent_getPointerCount(event);
+      if (count == 0)
+      {
+        CLog::Log(LOGWARNING,
+                  "CAndroidJoystickState: motion event with no active pointers from device {}",
+                  m_deviceId);
+        return false;
+      }
 
       bool success = false;
       for (size_t pointer = 0; pointer < count; ++pointer)

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -366,10 +366,10 @@ bool CAndroidJoystickState::ProcessEvent(const AInputEvent* event)
     case AINPUT_EVENT_TYPE_MOTION:
     {
       size_t count = AMotionEvent_getPointerCount(event);
-      if (count == 0)
+      if (count <= 0)
       {
         CLog::Log(LOGWARNING,
-                  "CAndroidJoystickState: motion event with no active pointers from device {}",
+                  "CAndroidJoystickState: motion event ignored - no active pointers from device {}",
                   m_deviceId);
         return false;
       }


### PR DESCRIPTION
## Summary
- avoid processing motion events with zero pointers on Android

## Testing
- `clang-format -i xbmc/platform/android/peripherals/AndroidJoystickState.cpp`


------
https://chatgpt.com/codex/tasks/task_e_683fdab467f083268f96867dbcfde56f