### PR TITLE
Fix Android joystick abort with zero pointers

### DIFF
--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -366,6 +366,13 @@ bool CAndroidJoystickState::ProcessEvent(const AInputEvent* event)
     case AINPUT_EVENT_TYPE_MOTION:
     {
       size_t count = AMotionEvent_getPointerCount(event);
+      if (count == 0)
+      {
+        CLog::Log(
+            LOGWARNING,
+            "CAndroidJoystickState: aborting motion event because there are no active pointers");
+        return false;
+      }
 
       bool success = false;
       for (size_t pointer = 0; pointer < count; ++pointer)


### PR DESCRIPTION
## Summary
- ignore joystick motion events with no active pointers

## Testing
- `clang-format -i xbmc/platform/android/peripherals/AndroidJoystickState.cpp`

------
https://chatgpt.com/codex/tasks/task_e_683fe5c931d48326a51aae50cf45d0e5