### PR TITLE
Add deserialization failure tests

### DIFF
--- a/cmake/treedata/common/games.txt
+++ b/cmake/treedata/common/games.txt
@@ -14,6 +14,7 @@ xbmc/games/controllers/types       games/controllers/types
 xbmc/games/controllers/windows     games/controllers/windows
 xbmc/games/dialogs                 games/dialogs
 xbmc/games/dialogs/osd             games/dialogs/osd
+xbmc/games/ports                   games/ports
 xbmc/games/ports/guicontrols       games/ports/guicontrols
 xbmc/games/ports/input             games/ports/input
 xbmc/games/ports/types             games/ports/types

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -7,6 +7,7 @@ xbmc/filesystem/test              test/filesystem
 xbmc/filesystem/VideoDatabaseDirectory/test test/videodatabasedirectory
 xbmc/games/addons/input/test      test/games/addons/input
 xbmc/games/controllers/input/test test/games/controllers/input
+xbmc/games/controllers/test       test/games/controllers
 xbmc/guilib/test                  test/guilib
 xbmc/imagefiles/test              test/imagefiles
 xbmc/input/keyboard/test          test/input/keyboard

--- a/xbmc/games/controllers/ControllerTranslator.cpp
+++ b/xbmc/games/controllers/ControllerTranslator.cpp
@@ -9,6 +9,7 @@
 #include "ControllerTranslator.h"
 
 #include "ControllerDefinitions.h"
+#include "games/ports/PortDefinitions.h"
 
 using namespace KODI;
 using namespace GAME;
@@ -168,4 +169,33 @@ INPUT_TYPE CControllerTranslator::TranslateInputType(const std::string& strType)
     return INPUT_TYPE::ANALOG;
 
   return INPUT_TYPE::UNKNOWN;
+}
+
+PORT_TYPE CControllerTranslator::TranslatePortType(const std::string& strPortType)
+{
+  if (strPortType == KEYBOARD_PORT_TYPE)
+    return PORT_TYPE::KEYBOARD;
+  else if (strPortType == MOUSE_PORT_TYPE)
+    return PORT_TYPE::MOUSE;
+  else if (strPortType == CONTROLLER_PORT_TYPE)
+    return PORT_TYPE::CONTROLLER;
+
+  return PORT_TYPE::UNKNOWN;
+}
+
+const char* CControllerTranslator::TranslatePortType(PORT_TYPE portType)
+{
+  switch (portType)
+  {
+    case PORT_TYPE::KEYBOARD:
+      return KEYBOARD_PORT_TYPE;
+    case PORT_TYPE::MOUSE:
+      return MOUSE_PORT_TYPE;
+    case PORT_TYPE::CONTROLLER:
+      return CONTROLLER_PORT_TYPE;
+    default:
+      break;
+  }
+
+  return "";
 }

--- a/xbmc/games/controllers/ControllerTranslator.h
+++ b/xbmc/games/controllers/ControllerTranslator.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "ControllerTypes.h"
 #include "input/joysticks/JoystickTypes.h"
 
 #include <string>
@@ -31,6 +32,9 @@ public:
 
   static const char* TranslateInputType(JOYSTICK::INPUT_TYPE type);
   static JOYSTICK::INPUT_TYPE TranslateInputType(const std::string& strType);
+
+  static PORT_TYPE TranslatePortType(const std::string& strPortType);
+  static const char* TranslatePortType(PORT_TYPE portType);
 };
 
 } // namespace GAME

--- a/xbmc/games/controllers/test/CMakeLists.txt
+++ b/xbmc/games/controllers/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestControllerTreeSerialization.cpp)
+
+core_add_test_library(test_games_controllers)

--- a/xbmc/games/controllers/test/CMakeLists.txt
+++ b/xbmc/games/controllers/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-set(SOURCES TestControllerTreeSerialization.cpp)
+set(SOURCES TestControllerTreeXML.cpp)
 
 core_add_test_library(test_games_controllers)

--- a/xbmc/games/controllers/test/TestControllerTreeSerialization.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeSerialization.cpp
@@ -19,6 +19,7 @@
 #include "utils/XBMCTinyXML2.h"
 
 #include <gtest/gtest.h>
+#include <string_view>
 
 using namespace KODI;
 using namespace GAME;
@@ -103,7 +104,7 @@ TEST(TestControllerTreeSerialization, DeserializeSimpleTree)
                     "</port>"
                     "</controller>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -156,7 +157,7 @@ TEST(TestControllerTreeSerialization, SerializeDeserializeRoundTrip)
 
   // Deserialize into a new hub
   CXBMCTinyXML2 doc2;
-  ASSERT_TRUE(doc2.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc2.Parse(xml) == tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement* root2 = doc2.RootElement();
   ASSERT_NE(root2, nullptr);
   CControllerHub hub2;
@@ -263,7 +264,7 @@ TEST(TestControllerTreeSerialization, DeserializePortMissingID)
                     "<accepts controller=\"game.controller.default\"/>"
                     "</port>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -279,7 +280,7 @@ TEST(TestControllerTreeSerialization, DeserializeControllerNodeMissingController
   // XML node missing the controller attribute
   const char* xml = "<accepts/>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -295,7 +296,7 @@ TEST(TestControllerTreeSerialization, DeserializeControllerNodeUnknownController
   // XML node referencing a non-existent controller id
   const char* xml = "<accepts controller=\"game.controller.fake\"/>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -313,7 +314,7 @@ TEST(TestControllerTreeSerialization, DeserializeHubInvalidPort)
                     "<port type=\"controller\"/>"
                     "</controller>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 

--- a/xbmc/games/controllers/test/TestControllerTreeSerialization.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeSerialization.cpp
@@ -1,0 +1,254 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "addons/AddonManager.h"
+#include "addons/addoninfo/AddonType.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
+#include "games/controllers/ControllerTranslator.h"
+#include "games/controllers/types/ControllerHub.h"
+#include "games/controllers/types/ControllerNode.h"
+#include "games/ports/types/PortNode.h"
+#include "test/TestUtils.h"
+#include "utils/XBMCTinyXML2.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+/*!
+ * Verify translation between port type strings and enums
+ */
+TEST(TestControllerTreeSerialization, TranslatePortType)
+{
+  // Ensure each known string maps to the correct enum value and back
+  EXPECT_EQ(CControllerTranslator::TranslatePortType("keyboard"), PORT_TYPE::KEYBOARD);
+  EXPECT_STREQ(CControllerTranslator::TranslatePortType(PORT_TYPE::KEYBOARD), "keyboard");
+
+  EXPECT_EQ(CControllerTranslator::TranslatePortType("mouse"), PORT_TYPE::MOUSE);
+  EXPECT_STREQ(CControllerTranslator::TranslatePortType(PORT_TYPE::MOUSE), "mouse");
+
+  EXPECT_EQ(CControllerTranslator::TranslatePortType("controller"), PORT_TYPE::CONTROLLER);
+  EXPECT_STREQ(CControllerTranslator::TranslatePortType(PORT_TYPE::CONTROLLER), "controller");
+
+  // Unknown strings should map to UNKNOWN
+  EXPECT_EQ(CControllerTranslator::TranslatePortType("unknown"), PORT_TYPE::UNKNOWN);
+}
+
+/*!
+ * Serialize a minimal controller tree to XML
+ *
+ * The tree contains one controller port accepting the default controller.
+ */
+TEST(TestControllerTreeSerialization, SerializeSimpleTree)
+{
+  // Load the default controller add-on
+  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  ADDON::AddonPtr addon;
+  ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+  ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+  ASSERT_NE(controller.get(), nullptr);
+
+  // Build the controller node
+  CControllerNode node;
+  node.SetController(controller);
+
+  // Build the port node accepting the controller
+  CPortNode port;
+  port.SetPortType(PORT_TYPE::CONTROLLER);
+  port.SetPortID("1");
+  port.SetCompatibleControllers({node});
+
+  // Build the hub containing the port
+  CControllerHub hub;
+  hub.SetPorts({port});
+
+  // Serialize to XML
+  CXBMCTinyXML2 doc;
+  auto* root = doc.NewElement("controller");
+  ASSERT_TRUE(hub.Serialize(*root));
+  doc.InsertFirstChild(root);
+
+  tinyxml2::XMLPrinter printer;
+  doc.Print(&printer);
+  std::string xml = printer.CStr();
+
+  // Validate the generated XML contains the expected attributes
+  EXPECT_NE(xml.find("<port"), std::string::npos);
+  EXPECT_NE(xml.find("type=\"controller\""), std::string::npos);
+  EXPECT_NE(xml.find("id=\"1\""), std::string::npos);
+  EXPECT_NE(xml.find("<accepts"), std::string::npos);
+  EXPECT_NE(xml.find("controller=\"game.controller.default\""), std::string::npos);
+}
+
+/*!
+ * Deserialize a simple controller tree from XML
+ *
+ * The XML contains one controller port accepting the default controller.
+ */
+TEST(TestControllerTreeSerialization, DeserializeSimpleTree)
+{
+  // Build an XML document representing a controller tree
+  const char* xml = "<controller>"
+                    "<port type=\"controller\" id=\"1\">"
+                    "<accepts controller=\"game.controller.default\"/>"
+                    "</port>"
+                    "</controller>";
+  CXBMCTinyXML2 doc;
+  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement* root = doc.RootElement();
+  ASSERT_NE(root, nullptr);
+
+  // Deserialize into a controller hub
+  CControllerHub hub;
+  ASSERT_TRUE(hub.Deserialize(*root));
+
+  // Validate the hub contents
+  ASSERT_EQ(hub.GetPorts().size(), 1u);
+  const CPortNode& port = hub.GetPorts().front();
+  EXPECT_EQ(port.GetPortType(), PORT_TYPE::CONTROLLER);
+  EXPECT_EQ(port.GetPortID(), "1");
+  ASSERT_EQ(port.GetCompatibleControllers().size(), 1u);
+  const CControllerNode& node = port.GetCompatibleControllers().front();
+  ASSERT_NE(node.GetController(), nullptr);
+  EXPECT_EQ(node.GetController()->ID(), std::string(DEFAULT_CONTROLLER_ID));
+}
+
+/*!
+ * Round trip a controller tree through serialization and deserialization
+ */
+TEST(TestControllerTreeSerialization, SerializeDeserializeRoundTrip)
+{
+  // Load the default controller add-on
+  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  ADDON::AddonPtr addon;
+  ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+  ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+  ASSERT_NE(controller.get(), nullptr);
+
+  // Build the original hub
+  CControllerNode node;
+  node.SetController(controller);
+  CPortNode port;
+  port.SetPortType(PORT_TYPE::CONTROLLER);
+  port.SetPortID("1");
+  port.SetCompatibleControllers({node});
+  CControllerHub hub;
+  hub.SetPorts({port});
+
+  // Serialize the hub
+  CXBMCTinyXML2 doc1;
+  auto* root1 = doc1.NewElement("controller");
+  ASSERT_TRUE(hub.Serialize(*root1));
+  doc1.InsertFirstChild(root1);
+  tinyxml2::XMLPrinter printer1;
+  doc1.Print(&printer1);
+  std::string xml = printer1.CStr();
+
+  // Deserialize into a new hub
+  CXBMCTinyXML2 doc2;
+  ASSERT_TRUE(doc2.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement* root2 = doc2.RootElement();
+  ASSERT_NE(root2, nullptr);
+  CControllerHub hub2;
+  ASSERT_TRUE(hub2.Deserialize(*root2));
+
+  // Verify the deserialized hub matches the original
+  ASSERT_EQ(hub2.GetPorts().size(), 1u);
+  const CPortNode& port2 = hub2.GetPorts().front();
+  EXPECT_EQ(port2.GetPortType(), PORT_TYPE::CONTROLLER);
+  EXPECT_EQ(port2.GetPortID(), "1");
+  ASSERT_EQ(port2.GetCompatibleControllers().size(), 1u);
+  const CControllerNode& node2 = port2.GetCompatibleControllers().front();
+  ASSERT_NE(node2.GetController(), nullptr);
+  EXPECT_EQ(node2.GetController()->ID(), std::string(DEFAULT_CONTROLLER_ID));
+}
+
+/*!
+ * Fail serialization for an unknown port type
+ */
+TEST(TestControllerTreeSerialization, SerializePortInvalidType)
+{
+  // Load the default controller add-on
+  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  ADDON::AddonPtr addon;
+  ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+  ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+  ASSERT_NE(controller.get(), nullptr);
+
+  // Build a port with no type set (defaults to UNKNOWN)
+  CControllerNode node;
+  node.SetController(controller);
+  CPortNode port;
+  port.SetPortID("1");
+  port.SetCompatibleControllers({node});
+
+  // Attempt serialization
+  CXBMCTinyXML2 doc;
+  auto* root = doc.NewElement("port");
+  EXPECT_FALSE(port.Serialize(*root));
+}
+
+/*!
+ * Fail serialization when a port is missing an id
+ */
+TEST(TestControllerTreeSerialization, SerializePortMissingID)
+{
+  // Load the default controller add-on
+  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  ADDON::AddonPtr addon;
+  ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+  ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+  ASSERT_NE(controller.get(), nullptr);
+
+  // Build a port with no id set
+  CControllerNode node;
+  node.SetController(controller);
+  CPortNode port;
+  port.SetPortType(PORT_TYPE::CONTROLLER);
+  port.SetCompatibleControllers({node});
+
+  // Attempt serialization
+  CXBMCTinyXML2 doc;
+  auto* root = doc.NewElement("port");
+  EXPECT_FALSE(port.Serialize(*root));
+}
+
+/*!
+ * Fail serialization when a port has no accepted controllers
+ */
+TEST(TestControllerTreeSerialization, SerializePortNoControllers)
+{
+  // Build a port with type and id but no controllers
+  CPortNode port;
+  port.SetPortType(PORT_TYPE::CONTROLLER);
+  port.SetPortID("1");
+
+  // Attempt serialization
+  CXBMCTinyXML2 doc;
+  auto* root = doc.NewElement("port");
+  EXPECT_FALSE(port.Serialize(*root));
+}
+
+/*!
+ * Fail serialization when a controller node lacks a controller profile
+ */
+TEST(TestControllerTreeSerialization, SerializeControllerNodeMissingController)
+{
+  CControllerNode node;
+
+  CXBMCTinyXML2 doc;
+  auto* root = doc.NewElement("accepts");
+  EXPECT_FALSE(node.Serialize(*root));
+}

--- a/xbmc/games/controllers/test/TestControllerTreeSerialization.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeSerialization.cpp
@@ -252,3 +252,71 @@ TEST(TestControllerTreeSerialization, SerializeControllerNodeMissingController)
   auto* root = doc.NewElement("accepts");
   EXPECT_FALSE(node.Serialize(*root));
 }
+
+/*!
+ * Fail deserialization when a port is missing an id
+ */
+TEST(TestControllerTreeSerialization, DeserializePortMissingID)
+{
+  // XML representing a port with a type but no id
+  const char* xml = "<port type=\"controller\">"
+                    "<accepts controller=\"game.controller.default\"/>"
+                    "</port>";
+  CXBMCTinyXML2 doc;
+  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement* root = doc.RootElement();
+  ASSERT_NE(root, nullptr);
+
+  CPortNode port;
+  EXPECT_FALSE(port.Deserialize(*root));
+}
+
+/*!
+ * Fail deserialization when a controller node lacks the controller attribute
+ */
+TEST(TestControllerTreeSerialization, DeserializeControllerNodeMissingController)
+{
+  // XML node missing the controller attribute
+  const char* xml = "<accepts/>";
+  CXBMCTinyXML2 doc;
+  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement* root = doc.RootElement();
+  ASSERT_NE(root, nullptr);
+
+  CControllerNode node;
+  EXPECT_FALSE(node.Deserialize(*root));
+}
+
+/*!
+ * Fail deserialization when a controller references an unknown profile
+ */
+TEST(TestControllerTreeSerialization, DeserializeControllerNodeUnknownController)
+{
+  // XML node referencing a non-existent controller id
+  const char* xml = "<accepts controller=\"game.controller.fake\"/>";
+  CXBMCTinyXML2 doc;
+  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement* root = doc.RootElement();
+  ASSERT_NE(root, nullptr);
+
+  CControllerNode node;
+  EXPECT_FALSE(node.Deserialize(*root));
+}
+
+/*!
+ * Fail deserialization of a hub when a child port is invalid
+ */
+TEST(TestControllerTreeSerialization, DeserializeHubInvalidPort)
+{
+  // XML hub containing a port with no id
+  const char* xml = "<controller>"
+                    "<port type=\"controller\"/>"
+                    "</controller>";
+  CXBMCTinyXML2 doc;
+  ASSERT_TRUE(doc.Parse(xml) == tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement* root = doc.RootElement();
+  ASSERT_NE(root, nullptr);
+
+  CControllerHub hub;
+  EXPECT_FALSE(hub.Deserialize(*root));
+}

--- a/xbmc/games/controllers/test/TestControllerTreeXML.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeXML.cpp
@@ -19,7 +19,6 @@
 #include "utils/XBMCTinyXML2.h"
 
 #include <gtest/gtest.h>
-#include <string_view>
 
 using namespace KODI;
 using namespace GAME;
@@ -103,8 +102,9 @@ TEST(TestControllerTreeXML, DeserializeSimpleTree)
                     "<accepts controller=\"game.controller.default\"/>"
                     "</port>"
                     "</controller>";
+  std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
+  ASSERT_TRUE(doc.Parse(xmlStr));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -263,8 +263,9 @@ TEST(TestControllerTreeXML, DeserializePortMissingID)
   const char* xml = "<port type=\"controller\">"
                     "<accepts controller=\"game.controller.default\"/>"
                     "</port>";
+  std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
+  ASSERT_TRUE(doc.Parse(xmlStr));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -279,8 +280,9 @@ TEST(TestControllerTreeXML, DeserializeControllerNodeMissingController)
 {
   // XML node missing the controller attribute
   const char* xml = "<accepts/>";
+  std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
+  ASSERT_TRUE(doc.Parse(xmlStr));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -295,8 +297,9 @@ TEST(TestControllerTreeXML, DeserializeControllerNodeUnknownController)
 {
   // XML node referencing a non-existent controller id
   const char* xml = "<accepts controller=\"game.controller.fake\"/>";
+  std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
+  ASSERT_TRUE(doc.Parse(xmlStr));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -313,8 +316,9 @@ TEST(TestControllerTreeXML, DeserializeHubInvalidPort)
   const char* xml = "<controller>"
                     "<port type=\"controller\"/>"
                     "</controller>";
+  std::string xmlStr{xml};
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
+  ASSERT_TRUE(doc.Parse(xmlStr));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 

--- a/xbmc/games/controllers/test/TestControllerTreeXML.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeXML.cpp
@@ -27,7 +27,7 @@ using namespace GAME;
 /*!
  * Verify translation between port type strings and enums
  */
-TEST(TestControllerTreeSerialization, TranslatePortType)
+TEST(TestControllerTreeXML, TranslatePortType)
 {
   // Ensure each known string maps to the correct enum value and back
   EXPECT_EQ(CControllerTranslator::TranslatePortType("keyboard"), PORT_TYPE::KEYBOARD);
@@ -48,7 +48,7 @@ TEST(TestControllerTreeSerialization, TranslatePortType)
  *
  * The tree contains one controller port accepting the default controller.
  */
-TEST(TestControllerTreeSerialization, SerializeSimpleTree)
+TEST(TestControllerTreeXML, SerializeSimpleTree)
 {
   // Load the default controller add-on
   ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
@@ -95,7 +95,7 @@ TEST(TestControllerTreeSerialization, SerializeSimpleTree)
  *
  * The XML contains one controller port accepting the default controller.
  */
-TEST(TestControllerTreeSerialization, DeserializeSimpleTree)
+TEST(TestControllerTreeXML, DeserializeSimpleTree)
 {
   // Build an XML document representing a controller tree
   const char* xml = "<controller>"
@@ -126,7 +126,7 @@ TEST(TestControllerTreeSerialization, DeserializeSimpleTree)
 /*!
  * Round trip a controller tree through serialization and deserialization
  */
-TEST(TestControllerTreeSerialization, SerializeDeserializeRoundTrip)
+TEST(TestControllerTreeXML, SerializeDeserializeRoundTrip)
 {
   // Load the default controller add-on
   ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
@@ -177,7 +177,7 @@ TEST(TestControllerTreeSerialization, SerializeDeserializeRoundTrip)
 /*!
  * Fail serialization for an unknown port type
  */
-TEST(TestControllerTreeSerialization, SerializePortInvalidType)
+TEST(TestControllerTreeXML, SerializePortInvalidType)
 {
   // Load the default controller add-on
   ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
@@ -203,7 +203,7 @@ TEST(TestControllerTreeSerialization, SerializePortInvalidType)
 /*!
  * Fail serialization when a port is missing an id
  */
-TEST(TestControllerTreeSerialization, SerializePortMissingID)
+TEST(TestControllerTreeXML, SerializePortMissingID)
 {
   // Load the default controller add-on
   ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
@@ -229,7 +229,7 @@ TEST(TestControllerTreeSerialization, SerializePortMissingID)
 /*!
  * Fail serialization when a port has no accepted controllers
  */
-TEST(TestControllerTreeSerialization, SerializePortNoControllers)
+TEST(TestControllerTreeXML, SerializePortNoControllers)
 {
   // Build a port with type and id but no controllers
   CPortNode port;
@@ -245,7 +245,7 @@ TEST(TestControllerTreeSerialization, SerializePortNoControllers)
 /*!
  * Fail serialization when a controller node lacks a controller profile
  */
-TEST(TestControllerTreeSerialization, SerializeControllerNodeMissingController)
+TEST(TestControllerTreeXML, SerializeControllerNodeMissingController)
 {
   CControllerNode node;
 
@@ -257,7 +257,7 @@ TEST(TestControllerTreeSerialization, SerializeControllerNodeMissingController)
 /*!
  * Fail deserialization when a port is missing an id
  */
-TEST(TestControllerTreeSerialization, DeserializePortMissingID)
+TEST(TestControllerTreeXML, DeserializePortMissingID)
 {
   // XML representing a port with a type but no id
   const char* xml = "<port type=\"controller\">"
@@ -275,7 +275,7 @@ TEST(TestControllerTreeSerialization, DeserializePortMissingID)
 /*!
  * Fail deserialization when a controller node lacks the controller attribute
  */
-TEST(TestControllerTreeSerialization, DeserializeControllerNodeMissingController)
+TEST(TestControllerTreeXML, DeserializeControllerNodeMissingController)
 {
   // XML node missing the controller attribute
   const char* xml = "<accepts/>";
@@ -291,7 +291,7 @@ TEST(TestControllerTreeSerialization, DeserializeControllerNodeMissingController
 /*!
  * Fail deserialization when a controller references an unknown profile
  */
-TEST(TestControllerTreeSerialization, DeserializeControllerNodeUnknownController)
+TEST(TestControllerTreeXML, DeserializeControllerNodeUnknownController)
 {
   // XML node referencing a non-existent controller id
   const char* xml = "<accepts controller=\"game.controller.fake\"/>";
@@ -307,7 +307,7 @@ TEST(TestControllerTreeSerialization, DeserializeControllerNodeUnknownController
 /*!
  * Fail deserialization of a hub when a child port is invalid
  */
-TEST(TestControllerTreeSerialization, DeserializeHubInvalidPort)
+TEST(TestControllerTreeXML, DeserializeHubInvalidPort)
 {
   // XML hub containing a port with no id
   const char* xml = "<controller>"

--- a/xbmc/games/controllers/test/TestControllerTreeXML.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeXML.cpp
@@ -104,7 +104,7 @@ TEST(TestControllerTreeXML, DeserializeSimpleTree)
                     "</port>"
                     "</controller>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -157,7 +157,7 @@ TEST(TestControllerTreeXML, SerializeDeserializeRoundTrip)
 
   // Deserialize into a new hub
   CXBMCTinyXML2 doc2;
-  ASSERT_TRUE(doc2.Parse(xml) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc2.Parse(xml));
   const tinyxml2::XMLElement* root2 = doc2.RootElement();
   ASSERT_NE(root2, nullptr);
   CControllerHub hub2;
@@ -264,7 +264,7 @@ TEST(TestControllerTreeXML, DeserializePortMissingID)
                     "<accepts controller=\"game.controller.default\"/>"
                     "</port>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -280,7 +280,7 @@ TEST(TestControllerTreeXML, DeserializeControllerNodeMissingController)
   // XML node missing the controller attribute
   const char* xml = "<accepts/>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -296,7 +296,7 @@ TEST(TestControllerTreeXML, DeserializeControllerNodeUnknownController)
   // XML node referencing a non-existent controller id
   const char* xml = "<accepts controller=\"game.controller.fake\"/>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 
@@ -314,7 +314,7 @@ TEST(TestControllerTreeXML, DeserializeHubInvalidPort)
                     "<port type=\"controller\"/>"
                     "</controller>";
   CXBMCTinyXML2 doc;
-  ASSERT_TRUE(doc.Parse(std::string_view{xml}) == tinyxml2::XML_SUCCESS);
+  ASSERT_TRUE(doc.Parse(std::string_view{xml}));
   const tinyxml2::XMLElement* root = doc.RootElement();
   ASSERT_NE(root, nullptr);
 

--- a/xbmc/games/controllers/types/ControllerHub.h
+++ b/xbmc/games/controllers/types/ControllerHub.h
@@ -13,6 +13,11 @@
 
 #include <string>
 
+namespace tinyxml2
+{
+class XMLElement;
+} // namespace tinyxml2
+
 namespace KODI
 {
 namespace GAME
@@ -52,6 +57,10 @@ public:
    * \param[out] inputPorts The list of input ports
    */
   void GetInputPorts(std::vector<std::string>& inputPorts) const;
+
+  // XML functions
+  bool Serialize(tinyxml2::XMLElement& controllerElement) const;
+  bool Deserialize(const tinyxml2::XMLElement& controllerElement);
 
 private:
   static const CPortNode& GetPortInternal(const PortVec& ports, const std::string& address);

--- a/xbmc/games/controllers/types/ControllerNode.h
+++ b/xbmc/games/controllers/types/ControllerNode.h
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+namespace tinyxml2
+{
+class XMLElement;
+} // namespace tinyxml2
+
 namespace KODI
 {
 namespace GAME
@@ -109,6 +114,10 @@ public:
    * \param[out] inputPorts The list of input ports
    */
   void GetInputPorts(std::vector<std::string>& activePorts) const;
+
+  // XML functions
+  bool Serialize(tinyxml2::XMLElement& controllerElement) const;
+  bool Deserialize(const tinyxml2::XMLElement& controllerElement);
 
 private:
   ControllerPtr m_controller;

--- a/xbmc/games/ports/CMakeLists.txt
+++ b/xbmc/games/ports/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(HEADERS PortDefinitions.h
+)
+
+if(NOT ENABLE_STATIC_LIBS)
+  core_add_library(games_ports)
+endif()

--- a/xbmc/games/ports/PortDefinitions.h
+++ b/xbmc/games/ports/PortDefinitions.h
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (C) 2024-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+// Port definitions
+constexpr auto KEYBOARD_PORT_TYPE = "keyboard";
+constexpr auto MOUSE_PORT_TYPE = "mouse";
+constexpr auto CONTROLLER_PORT_TYPE = "controller";

--- a/xbmc/games/ports/types/PortNode.cpp
+++ b/xbmc/games/ports/types/PortNode.cpp
@@ -8,15 +8,27 @@
 
 #include "PortNode.h"
 
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerTranslator.h"
 #include "games/controllers/types/ControllerHub.h"
 #include "games/ports/input/PhysicalPort.h"
+#include "utils/log.h"
 
 #include <algorithm>
 #include <utility>
 
+#include <tinyxml2.h>
+
 using namespace KODI;
 using namespace GAME;
+
+namespace
+{
+constexpr auto XML_ELM_ACCEPTS = "accepts";
+constexpr auto XML_ATTR_PORT_TYPE = "type";
+constexpr auto XML_ATTR_PORT_ID = "id";
+} // namespace
 
 CPortNode::~CPortNode() = default;
 
@@ -50,6 +62,11 @@ CPortNode& CPortNode::operator=(CPortNode&& rhs) noexcept
   }
 
   return *this;
+}
+
+void CPortNode::Clear()
+{
+  *this = CPortNode{};
 }
 
 const CControllerNode& CPortNode::GetActiveController() const
@@ -161,4 +178,113 @@ void CPortNode::GetPort(CPhysicalPort& port) const
   }
 
   port = CPhysicalPort(m_portId, std::move(accepts));
+}
+
+bool CPortNode::Serialize(tinyxml2::XMLElement& portElement) const
+{
+  // Validate state
+  if (m_portType == PORT_TYPE::UNKNOWN)
+  {
+    CLog::Log(LOGERROR, "Port type is unknown");
+    return false;
+  }
+  if (m_portId.empty())
+  {
+    CLog::Log(LOGERROR, "Port ID is empty");
+    return false;
+  }
+  if (m_controllers.empty())
+  {
+    CLog::Log(LOGERROR, "Port has no accepted controllers");
+    return false;
+  }
+
+  // Set the port type
+  portElement.SetAttribute(XML_ATTR_PORT_TYPE,
+                           CControllerTranslator::TranslatePortType(m_portType));
+
+  // Set the port ID
+  portElement.SetAttribute(XML_ATTR_PORT_ID, m_portId.c_str());
+
+  // Iterate and serialize each controller accepted by this port
+  for (const auto& controllerNode : m_controllers)
+  {
+    // Create a new "accepts" element
+    tinyxml2::XMLElement* acceptsElement = portElement.GetDocument()->NewElement(XML_ELM_ACCEPTS);
+    if (acceptsElement == nullptr)
+      return false;
+
+    // Serialize the controller node
+    if (!controllerNode.Serialize(*acceptsElement))
+      return false;
+
+    // Add the "accepts" element to the port element
+    portElement.InsertEndChild(acceptsElement);
+  }
+
+  return true;
+}
+
+bool CPortNode::Deserialize(const tinyxml2::XMLElement& portElement)
+{
+  Clear();
+
+  // Get port type
+  const char* portType = portElement.Attribute(XML_ATTR_PORT_TYPE);
+  if (portType != nullptr)
+    m_portType = CControllerTranslator::TranslatePortType(portType);
+
+  // Default to controller port
+  if (m_portType == PORT_TYPE::UNKNOWN)
+    m_portType = PORT_TYPE::CONTROLLER;
+
+  // Get port ID
+  const char* portId = portElement.Attribute(XML_ATTR_PORT_ID);
+  if (portId != nullptr)
+    m_portId = portId;
+  else
+  {
+    // Get port ID from port type
+    switch (m_portType)
+    {
+      case PORT_TYPE::KEYBOARD:
+        m_portId = KEYBOARD_PORT_ID;
+        break;
+      case PORT_TYPE::MOUSE:
+        m_portId = MOUSE_PORT_ID;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (m_portId.empty())
+  {
+    CLog::Log(LOGERROR, "Port of type {} is missing \"{}\" attribute",
+              CControllerTranslator::TranslatePortType(m_portType), XML_ATTR_PORT_ID);
+    return false;
+  }
+
+  // Get first "accepts" element
+  const tinyxml2::XMLElement* controllerElement = portElement.FirstChildElement(XML_ELM_ACCEPTS);
+  if (controllerElement == nullptr)
+  {
+    CLog::Log(LOGERROR, "Port {} of type {} is missing \"{}\" element", m_portId,
+              CControllerTranslator::TranslatePortType(m_portType), XML_ELM_ACCEPTS);
+  }
+
+  // Iterate over all "accepts" elements
+  while (controllerElement != nullptr)
+  {
+    CControllerNode controllerNode;
+    if (!controllerNode.Deserialize(*controllerElement))
+      return false;
+
+    m_controllers.emplace_back(std::move(controllerNode));
+
+    // Get next "accepts" element
+    controllerElement = controllerElement->NextSiblingElement(XML_ELM_ACCEPTS);
+  }
+
+  return true;
 }

--- a/xbmc/games/ports/types/PortNode.h
+++ b/xbmc/games/ports/types/PortNode.h
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+namespace tinyxml2
+{
+class XMLElement;
+} // namespace tinyxml2
+
 namespace KODI
 {
 namespace GAME
@@ -34,6 +39,8 @@ public:
   CPortNode& operator=(const CPortNode& rhs);
   CPortNode& operator=(CPortNode&& rhs) noexcept;
   ~CPortNode();
+
+  void Clear();
 
   /*!
    * \brief Connection state of the port
@@ -118,6 +125,10 @@ public:
    * \param[out] inputPorts The list of input ports
    */
   void GetInputPorts(std::vector<std::string>& inputPorts) const;
+
+  // XML functions
+  bool Serialize(tinyxml2::XMLElement& portElement) const;
+  bool Deserialize(const tinyxml2::XMLElement& portElement);
 
 private:
   void GetPort(CPhysicalPort& port) const;


### PR DESCRIPTION
## Summary
- add negative tests for port and controller deserialization

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bb1858d883268636e7a24c028cfd