### PR TITLE
Add doc for CaptureStateBlock

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -60,6 +60,12 @@ public:
   void SetViewPort(const CRect& viewPort);
   void GetViewPort(CRect& viewPort);
   void SetScissors(const CRect& rect);
+  /**
+   * @brief Save the current render state so it can be restored later.
+   *
+   * This includes the currently bound VAO. Calls to this function must be
+   * paired with ApplyStateBlock() to restore the captured state.
+   */
   void CaptureStateBlock();
   void ApplyStateBlock();
   bool IsExtSupported(const char* extension);


### PR DESCRIPTION
## Summary
- document behavior of `CaptureStateBlock`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3de45a3c83269dc751c64733cf05