### PR TITLE
Clarify DX state capture

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -260,6 +260,8 @@ void CRPBaseRenderer::PreRender(bool clear)
     return;
 
   m_context.CaptureStateBlock();
+  // Note: CaptureStateBlock() does nothing for the DirectX backend since
+  // state restoration is handled separately.
 
   // Clear screen
   if (clear)

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -392,6 +392,9 @@ void CRenderSystemDX::CaptureStateBlock()
 {
   if (!m_bRenderCreated)
     return;
+
+  // Intentionally left empty - DirectX resources are restored when state
+  // blocks are applied, so we don't need to capture anything here.
 }
 
 void CRenderSystemDX::ApplyStateBlock()


### PR DESCRIPTION
## Summary
- document that CaptureStateBlock() is intentionally empty on DirectX
- explain DX behaviour when capturing state in CRPBaseRenderer

## Testing
- `cmake -S . -B build -GNinja -DAPP_RENDER_SYSTEM=gl` *(fails: Could NOT find UDEV)*

------
https://chatgpt.com/codex/tasks/task_e_684b3de533a8832695383515a0486d35