### PR TITLE
Reduce digest code duplication

### DIFF
--- a/xbmc/games/controllers/types/ControllerHub.cpp
+++ b/xbmc/games/controllers/types/ControllerHub.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ControllerHub.h"
+#include "DigestUtils.h"
 
 #include "ControllerTree.h"
 #include "games/controllers/Controller.h"
@@ -171,10 +172,8 @@ bool CControllerHub::Deserialize(const tinyxml2::XMLElement& controllerElement)
 
 std::string CControllerHub::GetDigest(UTILITY::CDigest::Type digestType) const
 {
-  UTILITY::CDigest digest{digestType};
-
-  for (const CPortNode& port : m_ports)
-    digest.Update(port.GetDigest(digestType));
-
-  return digest.FinalizeRaw();
+  return DIGEST::ComposeDigest(digestType, [this, digestType](UTILITY::CDigest& digest) {
+    for (const CPortNode& port : m_ports)
+      digest.Update(port.GetDigest(digestType));
+  });
 }

--- a/xbmc/games/controllers/types/ControllerNode.cpp
+++ b/xbmc/games/controllers/types/ControllerNode.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ControllerNode.h"
+#include "DigestUtils.h"
 
 #include "ControllerHub.h"
 #include "ServiceBroker.h"
@@ -204,11 +205,9 @@ bool CControllerNode::Deserialize(const tinyxml2::XMLElement& controllerElement)
 
 std::string CControllerNode::GetDigest(UTILITY::CDigest::Type digestType) const
 {
-  UTILITY::CDigest digest{digestType};
-
-  if (m_controller)
-    digest.Update(m_controller->ID());
-  digest.Update(m_hub->GetDigest(digestType));
-
-  return digest.FinalizeRaw();
+  return DIGEST::ComposeDigest(digestType, [this, digestType](UTILITY::CDigest& digest) {
+    if (m_controller)
+      digest.Update(m_controller->ID());
+    digest.Update(m_hub->GetDigest(digestType));
+  });
 }

--- a/xbmc/games/controllers/types/DigestUtils.h
+++ b/xbmc/games/controllers/types/DigestUtils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "utils/Digest.h"
+
+namespace KODI
+{
+namespace GAME
+{
+namespace DIGEST
+{
+
+// Helper to compute digest using a provided updater callback
+// The callback receives a reference to UTILITY::CDigest and can call Update()
+// with all pieces contributing to the digest.
+
+template <typename Updater>
+inline std::string ComposeDigest(UTILITY::CDigest::Type type, Updater updater)
+{
+  UTILITY::CDigest digest{type};
+  updater(digest);
+  return digest.FinalizeRaw();
+}
+
+} // namespace DIGEST
+} // namespace GAME
+} // namespace KODI
+

--- a/xbmc/games/ports/types/PortNode.cpp
+++ b/xbmc/games/ports/types/PortNode.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "PortNode.h"
+#include "DigestUtils.h"
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
 #include "games/controllers/Controller.h"
@@ -292,13 +293,10 @@ bool CPortNode::Deserialize(const tinyxml2::XMLElement& portElement)
 
 std::string CPortNode::GetDigest(UTILITY::CDigest::Type digestType) const
 {
-  UTILITY::CDigest digest{digestType};
-
-  digest.Update(CControllerTranslator::TranslatePortType(m_portType));
-  digest.Update(m_portId);
-
-  for (const CControllerNode& controller : m_controllers)
-    digest.Update(controller.GetDigest(digestType));
-
-  return digest.FinalizeRaw();
+  return DIGEST::ComposeDigest(digestType, [this, digestType](UTILITY::CDigest& digest) {
+    digest.Update(CControllerTranslator::TranslatePortType(m_portType));
+    digest.Update(m_portId);
+    for (const CControllerNode& controller : m_controllers)
+      digest.Update(controller.GetDigest(digestType));
+  });
 }


### PR DESCRIPTION
## Summary
- add `DigestUtils.h` with helper to build digests
- use the helper in `ControllerHub`, `ControllerNode` and `PortNode`

## Testing
- `cmake -S . -B build` *(fails: You need to decide whether you want to use GL- or GLES-based rendering)*

------
https://chatgpt.com/codex/tasks/task_e_6850810b7f1883269af0901fc15bb08a