### PR TITLE
Support multiple mouse pointers in controller activity

### DIFF
--- a/xbmc/games/controllers/input/ControllerActivity.cpp
+++ b/xbmc/games/controllers/input/ControllerActivity.cpp
@@ -27,12 +27,23 @@ constexpr auto MOUSE_MOTION_TIMEOUT = 50ms;
 
 float CControllerActivity::GetActivation() const
 {
-  // De-activate mouse if an event hasn't been sent since last motion
-  if (m_mouseActive && m_motionTimer.IsTimePast() && m_activeButtons.empty())
+  bool anyPointerActive = false;
+  for (auto& it : m_mousePointers)
   {
-    m_lastActivation = 0.0f;
-    m_mouseActive = false;
+    MousePointer& pointer = it.second;
+    if (pointer.active)
+    {
+      if (pointer.timer.IsTimePast() && m_activeButtons.empty())
+      {
+        pointer.active = false;
+      }
+      if (pointer.active)
+        anyPointerActive = true;
+    }
   }
+
+  if (!anyPointerActive && m_activeButtons.empty())
+    m_lastActivation = 0.0f;
 
   return m_lastActivation;
 }
@@ -42,11 +53,9 @@ void CControllerActivity::ClearButtonState()
   m_lastActivation = 0.0f;
   m_currentActivation = 0.0f;
   m_activeKey.clear();
-  m_activePointers.clear();
+  m_mousePointers.clear();
   m_activeButtons.clear();
   m_bKeyPressed = false;
-  m_mouseActive = false;
-  m_motionTimer.SetExpired();
 }
 
 void CControllerActivity::OnButtonPress(bool pressed)
@@ -100,8 +109,9 @@ void CControllerActivity::OnMouseMotion(const MOUSE::PointerName& relpointer,
                                         int differenceX,
                                         int differenceY)
 {
-  m_mouseActive = true;
-  m_motionTimer.Set(MOUSE_MOTION_TIMEOUT);
+  auto& pointer = m_mousePointers[relpointer];
+  pointer.active = true;
+  pointer.timer.Set(MOUSE_MOTION_TIMEOUT);
 }
 
 void CControllerActivity::OnMouseButtonPress(const MOUSE::ButtonName& button)
@@ -127,8 +137,15 @@ void CControllerActivity::OnInputFrame()
       m_currentActivation = 1.0f;
 
     // Process mouse motion
-    if (m_mouseActive && !m_motionTimer.IsTimePast())
-      m_currentActivation = 1.0f;
+    for (auto& it : m_mousePointers)
+    {
+      const MousePointer& pointer = it.second;
+      if (pointer.active && !pointer.timer.IsTimePast())
+      {
+        m_currentActivation = 1.0f;
+        break;
+      }
+    }
   }
 
   // Process activation

--- a/xbmc/games/controllers/input/ControllerActivity.h
+++ b/xbmc/games/controllers/input/ControllerActivity.h
@@ -12,6 +12,7 @@
 #include "input/mouse/MouseTypes.h"
 #include "threads/SystemClock.h"
 
+#include <map>
 #include <set>
 
 namespace KODI
@@ -49,16 +50,21 @@ public:
   void OnInputFrame();
 
 private:
+  struct MousePointer
+  {
+    bool active{false};
+    XbmcThreads::EndTime<> timer;
+  };
+
   // State parameters
   // Required mutable because mouse motion may timeout without further mouse events
   mutable float m_lastActivation{0.0f};
   float m_currentActivation{0.0f};
   KEYBOARD::KeyName m_activeKey;
-  std::set<MOUSE::PointerName> m_activePointers;
+  std::map<MOUSE::PointerName, MousePointer> m_mousePointers;
   std::set<MOUSE::ButtonName> m_activeButtons;
   bool m_bKeyPressed{false};
-  mutable bool m_mouseActive{false};
-  XbmcThreads::EndTime<> m_motionTimer;
+  // m_mousePointers is mutable because timers may expire between frames
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/controllers/input/test/TestControllerActivity.cpp
+++ b/xbmc/games/controllers/input/test/TestControllerActivity.cpp
@@ -101,3 +101,25 @@ TEST(TestControllerActivity, MotionPersistsMultipleButtons)
   activity.OnMouseButtonRelease("right_button");
   EXPECT_FLOAT_EQ(activity.GetActivation(), 0.0f);
 }
+
+//
+// Spec: Multiple pointers should be tracked independently
+//
+TEST(TestControllerActivity, MultiplePointers)
+{
+  CControllerActivity activity;
+
+  activity.OnMouseMotion("pointer1", 1, 0);
+  activity.OnInputFrame();
+  EXPECT_FLOAT_EQ(activity.GetActivation(), 1.0f);
+
+  std::this_thread::sleep_for(30ms);
+  activity.OnMouseMotion("pointer2", 1, 0);
+  activity.OnInputFrame();
+
+  std::this_thread::sleep_for(40ms);
+  EXPECT_FLOAT_EQ(activity.GetActivation(), 1.0f);
+
+  std::this_thread::sleep_for(60ms);
+  EXPECT_FLOAT_EQ(activity.GetActivation(), 0.0f);
+}


### PR DESCRIPTION
## Summary
- handle multiple mouse pointers in `CControllerActivity`
- reset activation when all pointers expire
- add regression test for multiple pointers

## Testing
- `cmake -S . -B build -DENABLE_TESTING=ON` *(fails: "You need to decide whether you want to use GL- or GLES-based rendering")*

------
https://chatgpt.com/codex/tasks/task_e_685093533e9883269937c19fac12d85a