### PR TITLE
Fix nearest neighbor filtering on GL

### DIFF
--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -54,6 +54,12 @@ CTexture::~CTexture()
   m_pixels = NULL;
 }
 
+void CTexture::SetScalingMethod(TEXTURE_SCALING scalingMethod)
+{
+  m_scalingMethod = scalingMethod;
+  ApplyScalingMethod();
+}
+
 void CTexture::Update(unsigned int width,
                       unsigned int height,
                       unsigned int pitch,

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -120,13 +120,16 @@ public:
   virtual void CreateTextureObject() = 0;
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
-  /*! 
+  /*!
    * \brief Blocks execution until the previous GFX commands have been processed.
    */
   virtual void SyncGPU(){};
   virtual void BindToUnit(unsigned int unit) = 0;
 
-  /*! 
+  /*! \brief Set texture filtering method and update GPU state if needed */
+  virtual void SetScalingMethod(TEXTURE_SCALING scalingMethod);
+
+  /*!
    * \brief Checks if the processing pipeline can handle the texture format/swizzle
    \param format the format of the texture.
    \return true if the texturing pipeline supports the format
@@ -141,6 +144,7 @@ private:
   CTexture(const CTexture& copy) = delete;
 
 protected:
+  virtual void ApplyScalingMethod() {}
   bool LoadFromFileInMem(unsigned char* buffer,
                          size_t size,
                          const std::string& mimeType,

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -331,3 +331,26 @@ GLuint CGLTexture::GetTextureID() const
 {
   return m_texture;
 }
+
+void CGLTexture::ApplyScalingMethod()
+{
+  if (!m_loadedToGPU || m_texture == 0)
+    return;
+
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+
+  GLenum filter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_NEAREST : GL_LINEAR);
+
+  if (IsMipmapped())
+  {
+    GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST
+                                                                     : GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapFilter);
+  }
+  else
+  {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+  }
+
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+}

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -56,6 +56,9 @@ public:
   GLuint GetTextureID() const;
 
 protected:
+  void ApplyScalingMethod() override;
+
+protected:
   void SetSwizzle();
   TextureFormat GetFormatGL(KD_TEX_FMT textureFormat);
 

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -485,3 +485,26 @@ GLuint CGLESTexture::GetTextureID() const
 {
   return m_texture;
 }
+
+void CGLESTexture::ApplyScalingMethod()
+{
+  if (!m_loadedToGPU || m_texture == 0)
+    return;
+
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+
+  GLenum filter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_NEAREST : GL_LINEAR);
+
+  if (IsMipmapped())
+  {
+    GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST
+                                                                     : GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapFilter);
+  }
+  else
+  {
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+  }
+
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+}

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -48,6 +48,9 @@ public:
   GLuint GetTextureID() const;
 
 protected:
+  void ApplyScalingMethod() override;
+
+protected:
   void SetSwizzle(bool swapRB);
   void SwapBlueRedSwizzle(GLint& component);
   TextureFormat GetFormatGLES20(KD_TEX_FMT textureFormat);


### PR DESCRIPTION
## Summary
- allow runtime filtering updates via `CTexture::SetScalingMethod`
- adjust OpenGL texture classes to update filtering when loaded

## Testing
- `cmake -B build -DAPP_RENDER_SYSTEM=gl -DENABLE_INTERNAL_FFMPEG=ON` *(fails: Could NOT find UDEV)*

------
https://chatgpt.com/codex/tasks/task_e_6853248b5e0083268e36ec9fdd8f06ce