### PR TITLE
Enable nearest-neighbor CPU scaling

### DIFF
--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -13,6 +13,7 @@
 #include "commons/ilog.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/Texture.h"
+#include "guilib/TextureScaling.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/JobManager.h"
@@ -30,12 +31,14 @@ CImageLoader::CImageLoader(const std::string& path,
                            unsigned int targetWidth,
                            unsigned int targetHeight,
                            CAspectRatio::AspectRatio aspectRatio,
-                           const bool useCache)
+                           const bool useCache,
+                           TEXTURE_SCALING scalingMethod)
   : m_path(path),
     m_texture(nullptr),
     m_targetWidth(targetWidth),
     m_targetHeight(targetHeight),
-    m_aspectRatio(aspectRatio)
+    m_aspectRatio(aspectRatio),
+    m_scalingMethod(scalingMethod)
 {
   m_use_cache = useCache;
 }
@@ -60,7 +63,8 @@ bool CImageLoader::DoWork()
   {
     // direct route - load the image
     auto start = std::chrono::steady_clock::now();
-    m_texture = CTexture::LoadFromFile(loadPath, m_targetWidth, m_targetHeight, m_aspectRatio);
+    m_texture = CTexture::LoadFromFile(loadPath, m_targetWidth, m_targetHeight, m_aspectRatio,
+                                       "", m_scalingMethod);
 
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -102,11 +106,13 @@ bool CImageLoader::DoWork()
 CGUILargeTextureManager::CLargeTexture::CLargeTexture(const std::string& path,
                                                       unsigned int targetWidth,
                                                       unsigned int targetHeight,
-                                                      CAspectRatio::AspectRatio aspectRatio)
+                                                      CAspectRatio::AspectRatio aspectRatio,
+                                                      TEXTURE_SCALING scalingMethod)
   : m_path(path),
     m_targetWidth(targetWidth),
     m_targetHeight(targetHeight),
-    m_aspectRatio(aspectRatio)
+    m_aspectRatio(aspectRatio),
+    m_scalingMethod(scalingMethod)
 {
   m_refCount = 1;
   m_timeToDelete = 0;
@@ -186,14 +192,16 @@ bool CGUILargeTextureManager::GetImage(const std::string& path,
                                        unsigned int height,
                                        CAspectRatio::AspectRatio aspectRatio,
                                        bool firstRequest,
-                                       const bool useCache)
+                                       const bool useCache,
+                                       TEXTURE_SCALING scalingMethod)
 {
   std::unique_lock lock(m_listSection);
   for (listIterator it = m_allocated.begin(); it != m_allocated.end(); ++it)
   {
     CLargeTexture *image = *it;
     if (image->GetPath() == path && image->GetTargetWidth() == width &&
-        image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio)
+        image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio &&
+        image->GetScalingMethod() == scalingMethod)
     {
       if (firstRequest)
         image->AddRef();
@@ -203,7 +211,7 @@ bool CGUILargeTextureManager::GetImage(const std::string& path,
   }
 
   if (firstRequest)
-    QueueImage(path, width, height, aspectRatio, useCache);
+    QueueImage(path, width, height, aspectRatio, useCache, scalingMethod);
 
   return true;
 }
@@ -212,14 +220,16 @@ void CGUILargeTextureManager::ReleaseImage(const std::string& path,
                                            unsigned int width,
                                            unsigned int height,
                                            CAspectRatio::AspectRatio aspectRatio,
-                                           bool immediately)
+                                           bool immediately,
+                                           TEXTURE_SCALING scalingMethod)
 {
   std::unique_lock lock(m_listSection);
   for (listIterator it = m_allocated.begin(); it != m_allocated.end(); ++it)
   {
     CLargeTexture *image = *it;
     if (image->GetPath() == path && image->GetTargetWidth() == width &&
-        image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio)
+        image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio &&
+        image->GetScalingMethod() == scalingMethod)
     {
       if (image->DecrRef(immediately) && immediately)
         m_allocated.erase(it);
@@ -232,7 +242,7 @@ void CGUILargeTextureManager::ReleaseImage(const std::string& path,
     CLargeTexture *image = it->second;
     if (image->GetPath() == path && image->GetTargetWidth() == width &&
         image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio &&
-        image->DecrRef(true))
+        image->GetScalingMethod() == scalingMethod && image->DecrRef(true))
     {
       // cancel this job
       CServiceBroker::GetJobManager()->CancelJob(id);
@@ -247,7 +257,8 @@ void CGUILargeTextureManager::QueueImage(const std::string& path,
                                          unsigned int width,
                                          unsigned int height,
                                          CAspectRatio::AspectRatio aspectRatio,
-                                         bool useCache)
+                                         bool useCache,
+                                         TEXTURE_SCALING scalingMethod)
 {
   if (path.empty())
     return;
@@ -257,7 +268,8 @@ void CGUILargeTextureManager::QueueImage(const std::string& path,
   {
     CLargeTexture *image = it->second;
     if (image->GetPath() == path && image->GetTargetWidth() == width &&
-        image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio)
+        image->GetTargetHeight() == height && image->GetAspectRatio() == aspectRatio &&
+        image->GetScalingMethod() == scalingMethod)
     {
       image->AddRef();
       return; // already queued
@@ -265,9 +277,9 @@ void CGUILargeTextureManager::QueueImage(const std::string& path,
   }
 
   // queue the item
-  CLargeTexture* image = new CLargeTexture(path, width, height, aspectRatio);
+  CLargeTexture* image = new CLargeTexture(path, width, height, aspectRatio, scalingMethod);
   unsigned int jobID = CServiceBroker::GetJobManager()->AddJob(
-      new CImageLoader(path, width, height, aspectRatio, useCache), this, CJob::PRIORITY_NORMAL);
+      new CImageLoader(path, width, height, aspectRatio, useCache, scalingMethod), this, CJob::PRIORITY_NORMAL);
   m_queued.emplace_back(jobID, image);
 }
 

--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -10,6 +10,7 @@
 
 #include "guilib/AspectRatio.h"
 #include "guilib/TextureManager.h"
+#include "guilib/TextureScaling.h"
 #include "threads/CriticalSection.h"
 #include "utils/Job.h"
 
@@ -35,7 +36,8 @@ public:
                unsigned int targetWidth,
                unsigned int targetHeight,
                CAspectRatio::AspectRatio aspectRatio,
-               const bool useCache);
+               const bool useCache,
+               TEXTURE_SCALING scalingMethod);
   ~CImageLoader() override;
 
   /*!
@@ -51,6 +53,7 @@ private:
   unsigned int m_targetWidth; ///< target width of the image
   unsigned int m_targetHeight; ///< target height of the image
   CAspectRatio::AspectRatio m_aspectRatio; ///< aspect ratio mode of the image
+  TEXTURE_SCALING m_scalingMethod{TEXTURE_SCALING::LINEAR};
 };
 
 /*!
@@ -99,7 +102,8 @@ public:
                 unsigned int height,
                 CAspectRatio::AspectRatio aspectRatio,
                 bool firstRequest,
-                bool useCache = true);
+                bool useCache = true,
+                TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   /*!
    \brief Request a texture to be unloaded.
@@ -118,7 +122,8 @@ public:
                     unsigned int width,
                     unsigned int height,
                     CAspectRatio::AspectRatio aspectRatio,
-                    bool immediately = false);
+                    bool immediately = false,
+                    TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   /*!
    \brief Cleanup images that are no longer in use.
@@ -138,7 +143,8 @@ private:
     explicit CLargeTexture(const std::string& path,
                            unsigned int targetWidth,
                            unsigned int targetHeight,
-                           CAspectRatio::AspectRatio aspectRatio);
+                           CAspectRatio::AspectRatio aspectRatio,
+                           TEXTURE_SCALING scalingMethod);
     virtual ~CLargeTexture();
 
     void AddRef();
@@ -151,6 +157,7 @@ private:
     unsigned int GetTargetWidth() const { return m_targetWidth; }
     unsigned int GetTargetHeight() const { return m_targetHeight; }
     CAspectRatio::AspectRatio GetAspectRatio() const { return m_aspectRatio; }
+    TEXTURE_SCALING GetScalingMethod() const { return m_scalingMethod; }
 
   private:
     static const unsigned int TIME_TO_DELETE = 2000;
@@ -161,6 +168,7 @@ private:
     unsigned int m_targetWidth;
     unsigned int m_targetHeight;
     CAspectRatio::AspectRatio m_aspectRatio;
+    TEXTURE_SCALING m_scalingMethod;
     unsigned int m_timeToDelete;
   };
 
@@ -168,7 +176,8 @@ private:
                   unsigned int width,
                   unsigned int height,
                   CAspectRatio::AspectRatio aspectRatio,
-                  bool useCache = true);
+                  bool useCache = true,
+                  TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   std::vector< std::pair<unsigned int, CLargeTexture *> > m_queued;
   std::vector<CLargeTexture *> m_allocated;

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -487,8 +487,9 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
   AVColorRange range = frame->color_range;
   AVPixelFormat pixFormat = ConvertFormats(frame);
 
+  int swsFlags = (m_scalingMethod == TEXTURE_SCALING::NEAREST) ? SWS_POINT : SWS_BICUBIC;
   SwsContext* context = sws_getContext(m_originalWidth, m_originalHeight, pixFormat, width, height,
-                                       AV_PIX_FMT_RGB32, SWS_BICUBIC, NULL, NULL, NULL);
+                                       AV_PIX_FMT_RGB32, swsFlags, NULL, NULL, NULL);
 
   if (range == AVCOL_RANGE_JPEG)
   {

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "iimage.h"
+#include "guilib/TextureScaling.h"
 
 #include <cstdint>
 #include <memory>
@@ -73,6 +74,8 @@ public:
 
   bool Initialize(unsigned char* buffer, size_t bufSize);
 
+  void SetScalingMethod(TEXTURE_SCALING method) { m_scalingMethod = method; }
+
   std::shared_ptr<Frame> ReadFrame();
 
 private:
@@ -94,4 +97,5 @@ private:
 
   AVFrame* m_pFrame;
   uint8_t* m_outputBuffer;
+  TEXTURE_SCALING m_scalingMethod{TEXTURE_SCALING::LINEAR};
 };

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -63,6 +63,15 @@ public:
 
   bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize,
                            unsigned int width, unsigned int height) override;
+  bool LoadImageFromMemory(unsigned char* buffer,
+                           unsigned int bufSize,
+                           unsigned int width,
+                           unsigned int height,
+                           TEXTURE_SCALING scalingMethod) override
+  {
+    SetScalingMethod(scalingMethod);
+    return LoadImageFromMemory(buffer, bufSize, width, height);
+  }
   bool Decode(unsigned char * const pixels, unsigned int width, unsigned int height,
               unsigned int pitch, unsigned int format) override;
   bool CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width,

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -375,7 +375,7 @@ bool CGUITexture::AllocResources()
       }
       if (CServiceBroker::GetGUI()->GetLargeTextureManager().GetImage(
               m_info.filename, texture, m_requestWidth, m_requestHeight, m_aspect.ratio,
-              !IsAllocated(), m_use_cache))
+              !IsAllocated(), m_use_cache, m_scalingMethod))
       {
         m_isAllocated = LARGE;
 
@@ -524,7 +524,7 @@ void CGUITexture::FreeResources(bool immediately /* = false */)
   {
     CServiceBroker::GetGUI()->GetLargeTextureManager().ReleaseImage(
         m_info.filename, m_requestWidth, m_requestHeight, m_aspect.ratio,
-        immediately || (m_isAllocated == LARGE_FAILED));
+        immediately || (m_isAllocated == LARGE_FAILED), m_scalingMethod);
     m_requestWidth = REQUEST_SIZE_UNSET;
     m_requestHeight = REQUEST_SIZE_UNSET;
     CServiceBroker::GetGUI()->GetTextureCallbackManager().UnregisterOnWindowResizeCallback(*this);

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -263,11 +263,8 @@ bool CTexture::LoadIImage(IImage* pImage,
     return false;
 
   unsigned int maxTextureSize = CServiceBroker::GetRenderSystem()->GetMaxTextureSize();
-  if (!pImage->LoadImageFromMemory(buffer, bufSize, maxTextureSize, maxTextureSize))
+  if (!pImage->LoadImageFromMemory(buffer, bufSize, maxTextureSize, maxTextureSize, scalingMethod))
     return false;
-
-  if (auto ffmpegImage = dynamic_cast<CFFmpegImage*>(pImage))
-    ffmpegImage->SetScalingMethod(scalingMethod);
 
   if (pImage->Width() == 0 || pImage->Height() == 0)
     return false;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -106,7 +106,8 @@ std::unique_ptr<CTexture> CTexture::LoadFromFile(const std::string& texturePath,
                                                  unsigned int idealWidth,
                                                  unsigned int idealHeight,
                                                  CAspectRatio::AspectRatio aspectRatio,
-                                                 const std::string& strMimeType)
+                                                 const std::string& strMimeType,
+                                                 TEXTURE_SCALING scalingMethod)
 {
 #if defined(TARGET_ANDROID)
   CURL url(texturePath);
@@ -131,7 +132,8 @@ std::unique_ptr<CTexture> CTexture::LoadFromFile(const std::string& texturePath,
   }
 #endif
   std::unique_ptr<CTexture> texture = CTexture::CreateTexture();
-  if (texture->LoadFromFileInternal(texturePath, idealWidth, idealHeight, aspectRatio, strMimeType))
+  if (texture->LoadFromFileInternal(texturePath, idealWidth, idealHeight, aspectRatio, strMimeType,
+                                    scalingMethod))
     return texture;
   return {};
 }
@@ -141,11 +143,12 @@ std::unique_ptr<CTexture> CTexture::LoadFromFileInMemory(unsigned char* buffer,
                                                          const std::string& mimeType,
                                                          unsigned int idealWidth,
                                                          unsigned int idealHeight,
-                                                         CAspectRatio::AspectRatio aspectRatio)
+                                                         CAspectRatio::AspectRatio aspectRatio,
+                                                         TEXTURE_SCALING scalingMethod)
 {
   std::unique_ptr<CTexture> texture = CTexture::CreateTexture();
   if (texture->LoadFromFileInMem(buffer, bufferSize, mimeType, idealWidth, idealHeight,
-                                 aspectRatio))
+                                 aspectRatio, scalingMethod))
     return texture;
   return {};
 }
@@ -154,7 +157,8 @@ bool CTexture::LoadFromFileInternal(const std::string& texturePath,
                                     unsigned int idealWidth,
                                     unsigned int idealHeight,
                                     CAspectRatio::AspectRatio aspectRatio,
-                                    const std::string& strMimeType)
+                                    const std::string& strMimeType,
+                                    TEXTURE_SCALING scalingMethod)
 {
   if (URIUtils::HasExtension(texturePath, ".dds"))
   { // special case for DDS images
@@ -213,7 +217,8 @@ bool CTexture::LoadFromFileInternal(const std::string& texturePath,
   else
     pImage = ImageFactory::CreateLoaderFromMimeType(strMimeType);
 
-  if (!LoadIImage(pImage, buf.data(), buf.size(), idealWidth, idealHeight, aspectRatio))
+  if (!LoadIImage(pImage, buf.data(), buf.size(), idealWidth, idealHeight, aspectRatio,
+                  scalingMethod))
   {
     CLog::Log(LOGDEBUG, "{} - Load of {} failed.", __FUNCTION__, CURL::GetRedacted(texturePath));
     delete pImage;
@@ -229,13 +234,15 @@ bool CTexture::LoadFromFileInMem(unsigned char* buffer,
                                  const std::string& mimeType,
                                  unsigned int idealWidth,
                                  unsigned int idealHeight,
-                                 CAspectRatio::AspectRatio aspectRatio)
+                                 CAspectRatio::AspectRatio aspectRatio,
+                                 TEXTURE_SCALING scalingMethod)
 {
   if (!buffer || !size)
     return false;
 
   IImage* pImage = ImageFactory::CreateLoaderFromMimeType(mimeType);
-  if (!LoadIImage(pImage, buffer, size, idealWidth, idealHeight, aspectRatio))
+  if (!LoadIImage(pImage, buffer, size, idealWidth, idealHeight, aspectRatio,
+                  scalingMethod))
   {
     delete pImage;
     return false;
@@ -249,7 +256,8 @@ bool CTexture::LoadIImage(IImage* pImage,
                           unsigned int bufSize,
                           unsigned int idealWidth,
                           unsigned int idealHeight,
-                          CAspectRatio::AspectRatio aspectRatio)
+                          CAspectRatio::AspectRatio aspectRatio,
+                          TEXTURE_SCALING scalingMethod)
 {
   if (pImage == nullptr)
     return false;
@@ -257,6 +265,9 @@ bool CTexture::LoadIImage(IImage* pImage,
   unsigned int maxTextureSize = CServiceBroker::GetRenderSystem()->GetMaxTextureSize();
   if (!pImage->LoadImageFromMemory(buffer, bufSize, maxTextureSize, maxTextureSize))
     return false;
+
+  if (auto ffmpegImage = dynamic_cast<CFFmpegImage*>(pImage))
+    ffmpegImage->SetScalingMethod(scalingMethod);
 
   if (pImage->Width() == 0 || pImage->Height() == 0)
     return false;

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -53,7 +53,8 @@ public:
       unsigned int idealWidth = 0,
       unsigned int idealHeight = 0,
       CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
-      const std::string& strMimeType = "");
+      const std::string& strMimeType = "",
+      TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   /*! \brief Load a texture from a file in memory
    Loads a texture from a file in memory, restricting in size if needed based on maxHeight and maxWidth.
@@ -72,7 +73,8 @@ public:
       const std::string& mimeType,
       unsigned int idealWidth = 0,
       unsigned int idealHeight = 0,
-      CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER);
+      CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
+      TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
 
   bool LoadFromMemory(unsigned int width,
                       unsigned int height,
@@ -150,16 +152,19 @@ protected:
                          const std::string& mimeType,
                          unsigned int idealWidth,
                          unsigned int idealHeight,
-                         CAspectRatio::AspectRatio aspectRatio);
+                         CAspectRatio::AspectRatio aspectRatio,
+                         TEXTURE_SCALING scalingMethod);
   bool LoadFromFileInternal(const std::string& texturePath,
                             unsigned int idealWidth,
                             unsigned int idealHeight,
                             CAspectRatio::AspectRatio aspectRatio,
-                            const std::string& strMimeType = "");
+                            const std::string& strMimeType = "",
+                            TEXTURE_SCALING scalingMethod = TEXTURE_SCALING::LINEAR);
   bool LoadIImage(IImage* pImage,
                   unsigned char* buffer,
                   unsigned int bufSize,
                   unsigned int idealWidth,
                   unsigned int idealHeight,
-                  CAspectRatio::AspectRatio aspectRatio);
+                  CAspectRatio::AspectRatio aspectRatio,
+                  TEXTURE_SCALING scalingMethod);
 };

--- a/xbmc/guilib/iimage.h
+++ b/xbmc/guilib/iimage.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include "guilib/TextureScaling.h"
 
 class IImage
 {
@@ -25,6 +26,23 @@ public:
    \return true if the image could be loaded
    */
   virtual bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height)=0;
+
+  /*! \brief Load an image from memory with an explicit scaling method
+   \param buffer The memory location where the image data can be found
+   \param bufSize The size of the buffer
+   \param width The ideal width of the texture
+   \param height The ideal height of the texture
+   \param scalingMethod Scaling algorithm to use while decoding
+   \return true if the image could be loaded
+   */
+  virtual bool LoadImageFromMemory(unsigned char* buffer,
+                                   unsigned int bufSize,
+                                   unsigned int width,
+                                   unsigned int height,
+                                   TEXTURE_SCALING scalingMethod)
+  {
+    return LoadImageFromMemory(buffer, bufSize, width, height);
+  }
   /*!
    \brief Decodes the previously loaded image data to the output buffer in 32 bit raw bits
    \param pixels The output buffer


### PR DESCRIPTION
## Summary
- propagate GUI image filter to large texture loader
- add scaling method to ffmpeg image decoder
- honor <imagefilter> when loading textures through large texture manager

## Testing
- `tools/buildsteps/linux/run-tests` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68534c661f7c8326a7aef66eccf3fd3d