### PR TITLE
RetroPlayer: delete stale renderers sooner

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -509,6 +509,11 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRendererForSettings(
 {
   std::shared_ptr<CRPBaseRenderer> renderer;
 
+  // Stale renderers may exist after stream reconfiguration. Clean them up before
+  // creating or using new renderers to ensure GL resources are deleted while
+  // their original context is still active.
+  m_staleRenderers.clear();
+
   {
     std::unique_lock lock(m_stateMutex);
     if (m_state == RENDER_STATE::UNCONFIGURED)


### PR DESCRIPTION
## Summary
- clean up old renderers before creating new ones so that GL resources are freed with the correct context

## Testing
- `cmake -DAPP_RENDER_SYSTEM=gl ..` *(fails: Could NOT find UDEV)*

------
https://chatgpt.com/codex/tasks/task_e_688500b84898832692b0f3adec72d240