### PR TITLE
Fix Doxygen WindowIDs table truncation

### DIFF
--- a/xbmc/guilib/WindowIDs.dox
+++ b/xbmc/guilib/WindowIDs.dox
@@ -67,7 +67,7 @@ This page shows the window names, the window definition, the window ID and the s
 | AddonInformation        | WINDOW_DIALOG_ADDON_INFO             | 10146     | DialogAddonInfo.xml                 |                                    |
 | TextViewer              | WINDOW_DIALOG_TEXT_VIEWER            | 10147     | DialogTextViewer.xml                |                                    |
 |                         | WINDOW_DIALOG_PLAY_EJECT             | 10148     | DialogConfirm.xml                   |                                    |
-| Peripherals             | WINDOW_DIALOG_PERIPHERALS            | 10149     | DialogSelect.xml                    | @skinning_v21 The "Peripherals" alias has been added for this window<p></p> |
+| Peripherals             | WINDOW_DIALOG_PERIPHERALS            | 10149     | DialogSelect.xml                    | The "Peripherals" alias has been added for this window ( @ref skinning_v21 "Skinning v21" ) |
 | PeripheralSettings      | WINDOW_DIALOG_PERIPHERAL_SETTINGS    | 10150     | DialogSettings.xml                  |                                    |
 | ExtendedProgressDialog  | WINDOW_DIALOG_EXT_PROGRESS           | 10151     | DialogExtendedProgressBar.xml       |                                    |
 | MediaFilter             | WINDOW_DIALOG_MEDIA_FILTER           | 10152     | DialogSettings.xml                  |                                    |
@@ -112,18 +112,18 @@ This page shows the window names, the window definition, the window ID and the s
 | FullscreenRadioPreview  | WINDOW_FULLSCREEN_RADIO_PREVIEW      | 10803     | None (shortcut to fullscreenradio)  |                                    |
 | FullscreenLivetvInput   | WINDOW_FULLSCREEN_LIVETV_INPUT       | 10804     | None (shortcut to fullscreenlivetv) |                                    |
 | FullscreenRadioInput    | WINDOW_FULLSCREEN_RADIO_INPUT        | 10805     | None (shortcut to fullscreenradio)  |                                    |
-| GameControllers         | WINDOW_DIALOG_GAME_CONTROLLERS       | 10820     | DialogGameControllers.xml           | @skinning_v17 **New window**<p></p> |
-| Games                   | WINDOW_GAMES                         | 10821     | MyGames.xml                         | @skinning_v18 **New window**<p></p> |
-| GameOSD                 | WINDOW_DIALOG_GAME_OSD               | 10822     | GameOSD.xml                         | @skinning_v18 **New window**<p></p> |
-| GameVideoFilter         | WINDOW_DIALOG_GAME_VIDEO_FILTER      | 10823     | DialogSelect.xml                    | @skinning_v18 **New window**<p></p> |
-| GameStretchMode         | WINDOW_DIALOG_GAME_STRETCH_MODE      | 10824     | DialogSelect.xml                    | @skinning_v18 **New window**<p></p> |
-| GameVolume              | WINDOW_DIALOG_GAME_VOLUME            | 10825     | DialogSlider.xml                    | @skinning_v18 **New window** See https://github.com/xbmc/xbmc/pull/12765<p></p> |
-| GameAdvancedSettings    | WINDOW_DIALOG_GAME_ADVANCED_SETTINGS | 10826     | DialogAddonSettings.xml             | @skinning_v18 **New window**<p></p> |
-| GameVideoRotation       | WINDOW_DIALOG_GAME_VIDEO_ROTATION    | 10827     | DialogSelect.xml                    | @skinning_v18 **New window**<p></p> |
-| GamePorts               | WINDOW_DIALOG_GAME_PORTS             | 10828     | DialogGameControllers.xml           | @skinning_v20 **New window** See https://github.com/xbmc/xbmc/pull/20505<p></p> |
-| InGameSaves             | WINDOW_DIALOG_IN_GAME_SAVES          | 10829     | DialogSelect.xml                    | @skinning_v20 **New window** Part of the GSoC 2020 Saved Game Manager<p></p> |
-| GameSaves               | WINDOW_DIALOG_GAME_SAVES             | 10830     | DialogSelect.xml                    | @skinning_v20 **New window** Part of the GSoC 2020 Saved Game Manager<p></p> |
-| GameAgents              | WINDOW_DIALOG_GAME_AGENTS            | 10831     | DialogGameControllers.xml           | @skinning_v21 **New window** See https://github.com/xbmc/xbmc/pull/23548<p></p> |
+| GameControllers         | WINDOW_DIALOG_GAME_CONTROLLERS       | 10820     | DialogGameControllers.xml           | **New window** ( @ref skinning_v17 "Skinning v17" ) |
+| Games                   | WINDOW_GAMES                         | 10821     | MyGames.xml                         | **New window** ( @ref skinning_v18 "Skinning v18" ) |
+| GameOSD                 | WINDOW_DIALOG_GAME_OSD               | 10822     | GameOSD.xml                         | **New window** ( @ref skinning_v18 "Skinning v18" ) |
+| GameVideoFilter         | WINDOW_DIALOG_GAME_VIDEO_FILTER      | 10823     | DialogSelect.xml                    | **New window** ( @ref skinning_v18 "Skinning v18" ) |
+| GameStretchMode         | WINDOW_DIALOG_GAME_STRETCH_MODE      | 10824     | DialogSelect.xml                    | **New window** ( @ref skinning_v18 "Skinning v18" ) |
+| GameVolume              | WINDOW_DIALOG_GAME_VOLUME            | 10825     | DialogSlider.xml                    | **New window** ( @ref skinning_v18 "Skinning v18" ) See https://github.com/xbmc/xbmc/pull/12765 |
+| GameAdvancedSettings    | WINDOW_DIALOG_GAME_ADVANCED_SETTINGS | 10826     | DialogAddonSettings.xml             | **New window** ( @ref skinning_v18 "Skinning v18" ) |
+| GameVideoRotation       | WINDOW_DIALOG_GAME_VIDEO_ROTATION    | 10827     | DialogSelect.xml                    | **New window** ( @ref skinning_v18 "Skinning v18" ) |
+| GamePorts               | WINDOW_DIALOG_GAME_PORTS             | 10828     | DialogGameControllers.xml           | **New window** ( @ref skinning_v20 "Skinning v20" ) See https://github.com/xbmc/xbmc/pull/20505 |
+| InGameSaves             | WINDOW_DIALOG_IN_GAME_SAVES          | 10829     | DialogSelect.xml                    | **New window** ( @ref skinning_v20 "Skinning v20" ) Part of the GSoC 2020 Saved Game Manager |
+| GameSaves               | WINDOW_DIALOG_GAME_SAVES             | 10830     | DialogSelect.xml                    | **New window** ( @ref skinning_v20 "Skinning v20" ) Part of the GSoC 2020 Saved Game Manager |
+| GameAgents              | WINDOW_DIALOG_GAME_AGENTS            | 10831     | DialogGameControllers.xml           | **New window** ( @ref skinning_v21 "Skinning v21" ) See https://github.com/xbmc/xbmc/pull/23548 |
 | Custom Skin Windows     | -                                    | -         | custom*.xml                         |                                    |
 | SelectDialog            | WINDOW_DIALOG_SELECT                 | 12000     | DialogSelect.xml                    |                                    |
 | MusicInformation        | WINDOW_DIALOG_MUSIC_INFO             | 12001     | DialogMusicInfo.xml                 |                                    |
@@ -133,13 +133,13 @@ This page shows the window names, the window definition, the window ID and the s
 | Visualisation           | WINDOW_VISUALISATION                 | 12006     | MusicVisualisation.xml              |                                    |
 | Slideshow               | WINDOW_SLIDESHOW                     | 12007     | SlideShow.xml                       |                                    |
 | DialogColorPicker       | WINDOW_DIALOG_COLOR_PICKER           | 12008     | DialogColorPicker.xml               |                                    |
-| SelectVideoVersion      | WINDOW_DIALOG_SELECT_VIDEO_VERSION   | 12015     | DialogSelect.xml                    | @skinning_v21 **New window** SelectVideoVersion |
-| SelectVideoExtra        | WINDOW_DIALOG_SELECT_VIDEO_EXTRA     | 12016     | DialogSelect.xml                    | @skinning_v21 **New window** SelectVideoExtra |
-| ManageVideoVersions     | WINDOW_DIALOG_MANAGE_VIDEO_VERSIONS  | 12004     | DialogVideoManager.xml              | @skinning_v21 **New window** ManageVideoVersions |
-| ManageVideoExtras       | WINDOW_DIALOG_MANAGE_VIDEO_EXTRAS    | 12017     | DialogVideoManager.xml              | @skinning_v21 **New window** ManageVideoExtras |
-| DialogSelectVideo       | WINDOW_DIALOG_SELECT_VIDEO_STREAM    | 12300     | DialogSelect.xml                    | @skinning_v22 **New window** DialogSelectVideo |
-| DialogSelectAudio       | WINDOW_DIALOG_SELECT_AUDIO_STREAM    | 12301     | DialogSelect.xml                    | @skinning_v22 **New window** DialogSelectAudio |
-| DialogSelectSubtitle    | WINDOW_DIALOG_SELECT_SUBTITLE_STREAM | 12302     | DialogSelect.xml                    | @skinning_v22 **New window** DialogSelectSubtitle |
+| SelectVideoVersion      | WINDOW_DIALOG_SELECT_VIDEO_VERSION   | 12015     | DialogSelect.xml                    | **New window** ( @ref skinning_v21 "Skinning v21" ) SelectVideoVersion |
+| SelectVideoExtra        | WINDOW_DIALOG_SELECT_VIDEO_EXTRA     | 12016     | DialogSelect.xml                    | **New window** ( @ref skinning_v21 "Skinning v21" ) SelectVideoExtra |
+| ManageVideoVersions     | WINDOW_DIALOG_MANAGE_VIDEO_VERSIONS  | 12004     | DialogVideoManager.xml              | **New window** ( @ref skinning_v21 "Skinning v21" ) ManageVideoVersions |
+| ManageVideoExtras       | WINDOW_DIALOG_MANAGE_VIDEO_EXTRAS    | 12017     | DialogVideoManager.xml              | **New window** ( @ref skinning_v21 "Skinning v21" ) ManageVideoExtras |
+| DialogSelectVideo       | WINDOW_DIALOG_SELECT_VIDEO_STREAM    | 12300     | DialogSelect.xml                    | **New window** ( @ref skinning_v22 "Skinning v22" ) DialogSelectVideo |
+| DialogSelectAudio       | WINDOW_DIALOG_SELECT_AUDIO_STREAM    | 12301     | DialogSelect.xml                    | **New window** ( @ref skinning_v22 "Skinning v22" ) DialogSelectAudio |
+| DialogSelectSubtitle    | WINDOW_DIALOG_SELECT_SUBTITLE_STREAM | 12302     | DialogSelect.xml                    | **New window** ( @ref skinning_v22 "Skinning v22" ) DialogSelectSubtitle |
 | Weather                 | WINDOW_WEATHER                       | 12600     | MyWeather.xml                       |                                    |
 | Screensaver             | WINDOW_SCREENSAVER                   | 12900     | none                                |                                    |
 | VideoOSD                | WINDOW_DIALOG_VIDEO_OSD              | 12901     | VideoOSD.xml                        |                                    |
@@ -149,7 +149,7 @@ This page shows the window names, the window definition, the window ID and the s
 | Splash                  | WINDOW_SPLASH                        | 12997     | none                                |                                    |
 | StartWindow             | WINDOW_START                         | 12998     | shortcut to the current startwindow |                                    |
 | Startup                 | WINDOW_STARTUP_ANIM                  | 12999     | Startup.xml                         |                                    |
-| FavouritesBrowser       | WINDOW_FAVOURITES                    | 10060     | MyFavourites.xml                    | @skinning_v20 **New window** FavouritesBrowser, replaces the old Favourites dialog.<p></p> |
+| FavouritesBrowser       | WINDOW_FAVOURITES                    | 10060     | MyFavourites.xml                    | **New window** ( @ref skinning_v20 "Skinning v20" ) FavouritesBrowser, replaces the old Favourites dialog. |
 
 \section window_ids_rm Additional revision history
 


### PR DESCRIPTION
## Summary
- prevent Doxygen from truncating the window ID table
- link skinning change notes inline instead of using block-level macros

## Testing
- `doxygen --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abec26a22c83268cba07ce07eeba04