### PR TITLE
Set weather addon default to Open-Meteo

### DIFF
--- a/system/settings/appliance.xml
+++ b/system/settings/appliance.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings version="1">
+  <section id="services">
+    <category id="weather">
+      <group id="1">
+        <setting id="weather.addon">
+          <default>weather.openmeteo</default>
+        </setting>
+      </group>
+    </category>
+  </section>
   <section id="system">
     <category id="addons">
       <group id="1">


### PR DESCRIPTION
## Summary
- default appliance weather addon to weather.openmeteo

## Testing
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_b_68ba2197bee0832ea0f3e5145aa389c5