### PR TITLE
Hide home image controls in OASIS service windows

### DIFF
--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -646,7 +646,7 @@
 					<control type="group">
 						<left>70</left>
 						<control type="image">
-							<visible>false</visible>
+							<visible>!String.IsEqual(Window.Property(Addon.ID),service.oasis)</visible>
 							<left>0</left>
 							<top>20</top>
 							<width>254</width>
@@ -694,7 +694,7 @@
 							<effect type="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="180,140" />
 						</animation>
 						<control type="image">
-							<visible>false</visible>
+							<visible>!String.IsEqual(Window.Property(Addon.ID),service.oasis)</visible>
 							<left>0</left>
 							<top>20</top>
 							<width>254</width>
@@ -704,7 +704,7 @@
 							<bordersize>20</bordersize>
 						</control>
 						<control type="image">
-							<visible>false</visible>
+							<visible>!String.IsEqual(Window.Property(Addon.ID),service.oasis)</visible>
 							<left>0</left>
 							<top>20</top>
 							<width>254</width>


### PR DESCRIPTION
## Summary
- Hide Estuary home widget image backgrounds when viewing any `service.oasis` add-on window
- Keep widget imagery visible on other screens such as the weather window

## Testing
- `xmllint --noout addons/skin.estuary/xml/Includes_Home.xml`

------
https://chatgpt.com/codex/tasks/task_b_68c189190ba0832e84e314962ff085b9