### PR TITLE
Ensure zoom view mode persists across playlist

### DIFF
--- a/addons/service.oasis/resources/lib/oasis/utils/playlist_player.py
+++ b/addons/service.oasis/resources/lib/oasis/utils/playlist_player.py
@@ -9,29 +9,40 @@
 ################################################################################
 
 import json
+from typing import Optional
 
 import xbmc  # pylint: disable=import-error
 
 
+def _set_view_mode_zoom() -> None:
+    # We need a small sleep, otherwise the JSON-RPC call fails to set the
+    # view mode. 1ms is enough on fast computers, but slower computers require
+    # a larger delay, around 10ms. In any case, 100ms should be sufficient.
+    xbmc.sleep(100)
+
+    xbmc.executeJSONRPC(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "Player.SetViewMode",
+                "params": {"viewmode": "zoom"},
+                "id": 1,
+            }
+        )
+    )
+
+
+class _ViewModePlayer(xbmc.Player):
+    def onAVStarted(self) -> None:  # pylint: disable=invalid-name
+        _set_view_mode_zoom()
+
+
 class PlaylistPlayer:
+    _player: Optional[_ViewModePlayer] = None
+
     @staticmethod
     def play_playlist(playlist: xbmc.PlayList) -> None:
-        xbmc.Player().play(playlist, windowed=True)
+        PlaylistPlayer._player = _ViewModePlayer()
+        PlaylistPlayer._player.play(playlist, windowed=True)
         xbmc.executebuiltin("PlayerControl(RepeatAll)")
 
-        # We need a small sleep, otherwise the JSON-RPC call fails to set the
-        # view mode. 1ms is enough on fast computers, but slower computers
-        # require a larger delay, around 10ms. In any case, 100ms should be
-        # sufficient.
-        xbmc.sleep(100)
-
-        xbmc.executeJSONRPC(
-            json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "Player.SetViewMode",
-                    "params": {"viewmode": "zoom"},
-                    "id": 1,
-                }
-            )
-        )


### PR DESCRIPTION
## Summary
- keep video view mode set to zoom whenever playback starts

## Testing
- `python -m py_compile addons/service.oasis/resources/lib/oasis/utils/playlist_player.py`
- `python -m tox -q` *(fails: No Python at 'py310')*

------
https://chatgpt.com/codex/tasks/task_b_68c28a2b7518832e96d7c92aeb2eaaf9