### PR TITLE
[i18n] Split ISO 639-2 name tables to reduce compile-time cost

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -158,18 +158,32 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
   {
     std::string_view name = strCharCode;
 
-    auto itt = std::ranges::lower_bound(
-        TableISO639_2AllNames, name, [](std::string_view a, std::string_view b)
+    const LCENTRY* entry = nullptr;
+    auto it = std::ranges::lower_bound(
+        TableISO639_2ByName, name, [](std::string_view a, std::string_view b)
         { return StringUtils::CompareNoCase(a, b) < 0; }, &LCENTRY::name);
-    if (itt != TableISO639_2AllNames.end() && StringUtils::EqualsNoCase(itt->name, name))
+    if (it != TableISO639_2ByName.end() && StringUtils::EqualsNoCase(it->name, name))
+    {
+      entry = &*it;
+    }
+    else
+    {
+      auto ita = std::ranges::lower_bound(
+          TableISO639_2_NamesByName, name, [](std::string_view a, std::string_view b)
+          { return StringUtils::CompareNoCase(a, b) < 0; }, &LCENTRY::name);
+      if (ita != TableISO639_2_NamesByName.end() && StringUtils::EqualsNoCase(ita->name, name))
+        entry = &*ita;
+    }
+
+    if (entry != nullptr)
     {
       // Map T to B code for the few languages that have differences
-      auto itb = std::ranges::lower_bound(ISO639_2_TB_Mappings, itt->code, {},
+      auto itb = std::ranges::lower_bound(ISO639_2_TB_Mappings, entry->code, {},
                                           &ISO639_2_TB::terminological);
-      if (itb != ISO639_2_TB_Mappings.end() && itb->terminological == itt->code)
+      if (itb != ISO639_2_TB_Mappings.end() && itb->terminological == entry->code)
         strISO6392B = LongCodeToString(itb->bibliographic);
       else
-        strISO6392B = LongCodeToString(itt->code);
+        strISO6392B = LongCodeToString(entry->code);
 
       return true;
     }
@@ -212,7 +226,6 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode,
   }
   return false;
 }
-
 
 bool CLangCodeExpander::LookupUserCode(const std::string& desc, std::string& userCode)
 {
@@ -387,11 +400,19 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
 
   {
     auto it = std::ranges::lower_bound(
-        TableISO639_2AllNames, name, [](std::string_view a, std::string_view b)
+        TableISO639_2ByName, name, [](std::string_view a, std::string_view b)
         { return StringUtils::CompareNoCase(a, b) < 0; }, &LCENTRY::name);
-    if (it != TableISO639_2AllNames.end() && StringUtils::EqualsNoCase(it->name, name))
+    if (it != TableISO639_2ByName.end() && StringUtils::EqualsNoCase(it->name, name))
     {
       code = LongCodeToString(it->code);
+      return true;
+    }
+    auto ita = std::ranges::lower_bound(
+        TableISO639_2_NamesByName, name, [](std::string_view a, std::string_view b)
+        { return StringUtils::CompareNoCase(a, b) < 0; }, &LCENTRY::name);
+    if (ita != TableISO639_2_NamesByName.end() && StringUtils::EqualsNoCase(ita->name, name))
+    {
+      code = LongCodeToString(ita->code);
       return true;
     }
   }
@@ -518,10 +539,12 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(
   if (format == CLangCodeExpander::ISO_639_2)
   {
     // ISO 639-2/T codes
-    std::ranges::transform(TableISO639_2AllNames, std::inserter(langMap, langMap.end()),
-                           [](const LCENTRY& e) {
-                             return std::make_pair(LongCodeToString(e.code), std::string{e.name});
-                           });
+    std::ranges::transform(
+        TableISO639_2ByName, std::inserter(langMap, langMap.end()), [](const LCENTRY& e)
+        { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
+    std::ranges::transform(
+        TableISO639_2_NamesByName, std::inserter(langMap, langMap.end()), [](const LCENTRY& e)
+        { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
 
     // ISO 639-2/B codes that are different from the T code.
     for (const ISO639_2_TB& tb : ISO639_2_TB_Mappings)
@@ -547,13 +570,13 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(
   }
   else
   {
-    std::ranges::transform(TableISO639_1ByName, std::inserter(langMap, langMap.end()),
-                           [](const LCENTRY& e) {
-                             return std::make_pair(LongCodeToString(e.code), std::string{e.name});
-                           });
+    std::ranges::transform(
+        TableISO639_1ByName, std::inserter(langMap, langMap.end()), [](const LCENTRY& e)
+        { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
 
     std::ranges::transform(TableISO639_1_DeprByName, std::inserter(langMap, langMap.end()),
-                           [](const LCENTRY& e) {
+                           [](const LCENTRY& e)
+                           {
                              return std::make_pair(LongCodeToString(e.code),
                                                    std::string{e.name} + " (Deprecated)");
                            });

--- a/xbmc/utils/i18n/TableISO639_2.h
+++ b/xbmc/utils/i18n/TableISO639_2.h
@@ -620,10 +620,10 @@ constexpr std::array<struct LCENTRY, ISO639_2_ADDL_NAMES_COUNT> TableISO639_2_Na
 // clang-format on
 
 static_assert(std::ranges::is_sorted(TableISO639_2_Names, {}, &LCENTRY::code));
-
-// Concatenate and sort the main + additional names to enable lookup of 639-2/T code from any name
-static constexpr auto TableISO639_2AllNames =
-    CreateIso639ByName(concat(TableISO639_2ByCode, TableISO639_2_Names));
+// Split the main and additional name tables to avoid a large compile-time
+// concatenation and sort operation.
+static constexpr auto TableISO639_2ByName = CreateIso639ByName(TableISO639_2ByCode);
+static constexpr auto TableISO639_2_NamesByName = CreateIso639ByName(TableISO639_2_Names);
 
 // clang-format off
 static constexpr std::array<ISO639_2_TB, 22> ISO639_2_TB_Mappings = {{


### PR DESCRIPTION
## Summary
- split main and additional ISO 639-2 name tables to avoid expensive compile-time concatenation and sort
- update LangCodeExpander to search the two pre-sorted arrays and adjust language name enumeration

## Testing
- `cmake -S . -B build -GNinja -DBUILD_TESTING=ON -DAPP_RENDER_SYSTEM=gl -DENABLE_INTERNAL_FFMPEG=ON -DCORE_PLATFORM_NAME=x11`
- `cmake --build build --target utils_test`
- `ctest -R LangCodeExpander --output-on-failure` *(fails: Unable to find executable: kodi-test)*
- `cmake --build build --target kodi-test` *(fails: ninja: build stopped: subcommand failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c485dfe34c832eb73f44fd2093064d