### PR TITLE
Configure Estuary skin for HD weather icons

### DIFF
--- a/addons/service.oasis/resources/lib/oasis/service.py
+++ b/addons/service.oasis/resources/lib/oasis/service.py
@@ -30,12 +30,32 @@ WINDOW_PROPERTY_HOSTNAME: str = "hostname"
 
 class OasisService:
     @staticmethod
+    def _configure_weather_icons() -> None:
+        """Configure Estuary skin to use HD animated weather icons."""
+        try:
+            skin = xbmcaddon.Addon(id="skin.estuary")
+            skin.setSettingBool("WeatherOutlookIcon.multi", True)
+            skin.setSettingString(
+                "weatheroutlookicon.path",
+                "resource://resource.images.weathericons.hd.animated/",
+            )
+            skin.setSettingString(
+                "WeatherOutlookIcon.name", "Weather Icons - HD Animated"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            xbmc.log(
+                f"Failed to configure weather icons: {exc}", level=xbmc.LOGERROR
+            )
+
+    @staticmethod
     def run(hostname: str) -> None:
         addon: xbmcaddon.Addon = xbmcaddon.Addon()
         addon_id = addon.getAddonInfo("id")
         addon_path: str = addon.getAddonInfo("path")
 
         xbmc.log(f"Running OASIS service on {hostname}", level=xbmc.LOGDEBUG)
+
+        OasisService._configure_weather_icons()
 
         # Set the hostname property for the home window
         home_win = xbmcgui.Window(HOME_WINDOW_ID)

--- a/userdata/addon_data/skin.estuary/settings.xml
+++ b/userdata/addon_data/skin.estuary/settings.xml
@@ -1,0 +1,19 @@
+<settings>
+    <setting id="album_onclick_play" type="bool">false</setting>
+    <setting id="album_onclick_playnext" type="bool">false</setting>
+    <setting id="album_onclick_queue" type="bool">false</setting>
+    <setting id="WeatherOutlookIcon.multi" type="bool">true</setting>
+    <setting id="MovieGenreFanart.ext" type="string"></setting>
+    <setting id="WeatherFanart.ext" type="string"></setting>
+    <setting id="homefanart.path" type="string"></setting>
+    <setting id="WeatherFanart.path" type="string"></setting>
+    <setting id="HomeFanart.ext" type="string"></setting>
+    <setting id="osdautoclosetime" type="string"></setting>
+    <setting id="weatheroutlookicon.path" type="string">resource://resource.images.weathericons.hd.animated/</setting>
+    <setting id="WeatherOutlookIcon.ext" type="string"></setting>
+    <setting id="background_overlay" type="string">1</setting>
+    <setting id="HomeFanart.name" type="string"></setting>
+    <setting id="WeatherFanart.name" type="string"></setting>
+    <setting id="MovieGenreFanart.Name" type="string"></setting>
+    <setting id="WeatherOutlookIcon.name" type="string">Weather Icons - HD Animated</setting>
+</settings>


### PR DESCRIPTION
## Summary
- Configure Estuary skin to use HD animated weather icons during service startup
- Provide default Estuary settings enabling the HD weather icon pack

## Testing
- `python -m py_compile addons/service.oasis/resources/lib/oasis/service.py`
- `xmllint --noout userdata/addon_data/skin.estuary/settings.xml`


------
https://chatgpt.com/codex/tasks/task_b_68c4f9e406e0832e846189e7bd32833c