### PR TITLE
Add advancedsettings to disable fullscreen on movie start

### DIFF
--- a/userdata/advancedsettings.xml
+++ b/userdata/advancedsettings.xml
@@ -1,0 +1,5 @@
+<advancedsettings>
+  <video>
+    <fullscreenonmoviestart>false</fullscreenonmoviestart>
+  </video>
+</advancedsettings>


### PR DESCRIPTION
## Summary
- provide an `advancedsettings.xml` that disables entering fullscreen automatically when movies start

## Testing
- `xmllint --noout userdata/advancedsettings.xml`


------
https://chatgpt.com/codex/tasks/task_b_68c7b40afa64832e946574423c0e2ece