### PR TITLE
Report capturing state with smart home peripherals

### DIFF
--- a/xbmc/smarthome/input/SmartHomeInputManager.cpp
+++ b/xbmc/smarthome/input/SmartHomeInputManager.cpp
@@ -111,3 +111,8 @@ void CSmartHomeInputManager::CloseJoystick(const std::string& peripheralLocation
   if (it != m_joysticks.end())
     m_joysticks.erase(it);
 }
+
+bool CSmartHomeInputManager::IsCapturingInput(const std::string& peripheralLocation) const
+{
+  return m_joysticks.find(peripheralLocation) != m_joysticks.end();
+}

--- a/xbmc/smarthome/input/SmartHomeInputManager.h
+++ b/xbmc/smarthome/input/SmartHomeInputManager.h
@@ -54,6 +54,8 @@ public:
                     ISmartHomeJoystickHandler& joystickHandler);
   void CloseJoystick(const std::string& peripheralLocation);
 
+  bool IsCapturingInput(const std::string& peripheralLocation) const;
+
 private:
   using PeripheralAddress = std::string;
   using JoystickMap = std::map<PeripheralAddress, std::unique_ptr<CSmartHomeJoystick>>;

--- a/xbmc/smarthome/ros2/Ros2InputPublisher.cpp
+++ b/xbmc/smarthome/ros2/Ros2InputPublisher.cpp
@@ -214,6 +214,8 @@ void CRos2InputPublisher::AddPeripherals(const PERIPHERALS::PeripheralVector& pe
     infoMessage.product_id = peripheral->ProductId();
     if (peripheral->ControllerProfile())
       infoMessage.controller_profile = peripheral->ControllerProfile()->ID();
+    infoMessage.capturing_input =
+        m_inputManager.IsCapturingInput(peripheral->Location());
 
     peripheralScan.emplace_back(std::move(infoMessage));
   }


### PR DESCRIPTION
## Summary
- add an accessor on the smart home input manager to expose which peripherals currently have active joystick captures
- include the capture state when publishing peripheral scan messages so remote clients can detect active input streams

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c913d53524832eb02cca036edb9825