### PR TITLE
Adjust ROS2 QoS queue depth

### DIFF
--- a/xbmc/smarthome/ros2/Ros2LabSubscriber.cpp
+++ b/xbmc/smarthome/ros2/Ros2LabSubscriber.cpp
@@ -56,7 +56,7 @@ void CRos2LabSubscriber::Initialize()
 
   // QoS policy
   rclcpp::SensorDataQoS qos;
-  const size_t queueSize = 10;
+  const size_t queueSize = 1;
   qos.keep_last(queueSize);
 
   // Subscribers

--- a/xbmc/smarthome/ros2/Ros2StationSubscriber.cpp
+++ b/xbmc/smarthome/ros2/Ros2StationSubscriber.cpp
@@ -57,7 +57,7 @@ void CRos2StationSubscriber::Initialize()
 
   // QoS policy
   rclcpp::SensorDataQoS qos;
-  const size_t queueSize = 10;
+  const size_t queueSize = 1;
   qos.keep_last(queueSize);
 
   // Subscribers

--- a/xbmc/smarthome/ros2/Ros2SystemHealthSubscriber.cpp
+++ b/xbmc/smarthome/ros2/Ros2SystemHealthSubscriber.cpp
@@ -48,7 +48,7 @@ void CRos2SystemHealthSubscriber::Initialize(std::shared_ptr<rclcpp::Node> node,
 
   // QoS policy
   rclcpp::SensorDataQoS qos;
-  const size_t queueSize = 10;
+  const size_t queueSize = 1;
   qos.keep_last(queueSize);
 
   // Subscribers


### PR DESCRIPTION
## Summary
- set all ROS2 subscribers to use a single-message SensorData QoS queue

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5ef866168832e9faea8d0442157d8