### PR TITLE
Add SmartHome CPU frequency label and HUD column

### DIFF
--- a/addons/service.oasis/resources/skins/default/1080i/Includes_StationHUD.xml
+++ b/addons/service.oasis/resources/skins/default/1080i/Includes_StationHUD.xml
@@ -20,6 +20,17 @@
             <aligny>center</aligny>
         </control>
         <control type="label">
+            <description>CPU Frequency</description>
+            <right>1320</right>
+            <label>$INFO[ListItem.Property(smarthome.cpufrequency)]</label>
+            <font>font_MainMenu</font>
+            <shadowcolor>text_shadow</shadowcolor>
+            <align>right</align>
+            <aligny>center</aligny>
+            <visible>!String.IsEmpty(ListItem.Property(smarthome.isactive))</visible>
+            <animation effect="fade" time="1500">VisibleChange</animation>
+        </control>
+        <control type="label">
             <description>CPU Usage</description>
             <right>1000</right>
             <label>$INFO[ListItem.Property(smarthome.cpuutilization)]</label>
@@ -66,6 +77,7 @@
         <item>
             <description>Dummy item with column headers</description>
             <property name="smarthome.isactive">true</property>
+            <property name="smarthome.cpufrequency">CPU Hz</property>
             <property name="smarthome.cpuutilization">CPU %</property>
             <property name="smarthome.cputemperature">CPU °F</property>
             <property name="smarthome.ramutilization">RAM %</property>
@@ -74,12 +86,14 @@
         <item>
             <label>Little Brain</label>
             <property name="smarthome.isactive">$VAR[OasisTrainSystemConductorIsActive]</property>
+            <property name="smarthome.cpufrequency">$INFO[SmartHome.System(conductor).CPUFrequency]</property>
             <property name="smarthome.ramutilization">$INFO[SmartHome.System(conductor).RAMUtilization]</property>
             <property name="smarthome.ramtotal">2048 B</property>
         </item>
         <item>
             <label>Big Brain</label>
             <property name="smarthome.isactive">$VAR[OasisTrainSystemStationIsActive]</property>
+            <property name="smarthome.cpufrequency">$INFO[SmartHome.System(station).CPUFrequency]</property>
             <property name="smarthome.cpuutilization">$INFO[SmartHome.System(station).CPUUtilization]</property>
             <property name="smarthome.cputemperature">$INFO[SmartHome.System(station).CPUTemperature]</property>
             <property name="smarthome.ramutilization">$INFO[SmartHome.System(station).RAMUtilization]</property>
@@ -88,6 +102,7 @@
         <item>
             <label>Mega Brain</label>
             <property name="smarthome.isactive">$VAR[OasisTrainSystemOceanPlatformIsActive]</property>
+            <property name="smarthome.cpufrequency">$INFO[SmartHome.System(oceanplatform).CPUFrequency]</property>
             <property name="smarthome.cpuutilization">$INFO[SmartHome.System(oceanplatform).CPUUtilization]</property>
             <property name="smarthome.cputemperature">$INFO[SmartHome.System(oceanplatform).CPUTemperature]</property>
             <property name="smarthome.ramutilization">$INFO[SmartHome.System(oceanplatform).RAMUtilization]</property>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4317,6 +4317,14 @@ constexpr std::array<InfoMap, 3> retroplayer = {{
 ///     @skinning_v22 **[New Infolabel]** \link SmartHome_System_CPUUtilization `SmartHome.System(name).CPUUtilization`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`SmartHome.System(name).CPUFrequency`</b>,
+///                  \anchor SmartHome_System_CPUFrequency
+///                  _string_,
+///     @return The CPU frequency of the given system, formatted with an appropriate unit
+///     <p><hr>
+///     @skinning_v25 **[New Infolabel]** \link SmartHome_System_CPUFrequency `SmartHome.System(name).CPUFrequency`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`SmartHome.System(name).RAMUtilization`</b>,
 ///                  \anchor SmartHome_System_RAMUtilization
 ///                  _string_,
@@ -4396,10 +4404,11 @@ constexpr std::array<InfoMap, 3> retroplayer = {{
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 15> smarthome = {{
+constexpr std::array<InfoMap, 16> smarthome = {{
     {"isactive",            SMARTHOME_IS_ACTIVE},
     {"cputemperature",      SMARTHOME_CPU_TEMPERATURE},
     {"cpuutilization",      SMARTHOME_CPU_UTILIZATION},
+    {"cpufrequency",        SMARTHOME_CPU_FREQUENCY},
     {"ramutilization",      SMARTHOME_RAM_UTILIZATION},
     {"haslab",              SMARTHOME_HAS_LAB},
     {"labcpu",              SMARTHOME_LAB_CPU},

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -537,6 +537,7 @@ constexpr uint32_t SMARTHOME_IS_ACTIVE               = 850;
 constexpr uint32_t SMARTHOME_CPU_TEMPERATURE         = 851;
 constexpr uint32_t SMARTHOME_CPU_UTILIZATION         = 852;
 constexpr uint32_t SMARTHOME_RAM_UTILIZATION         = 853;
+constexpr uint32_t SMARTHOME_CPU_FREQUENCY           = 854;
 
 constexpr uint32_t SMARTHOME_HAS_LAB                 = 860;
 constexpr uint32_t SMARTHOME_LAB_CPU                 = 861;

--- a/xbmc/smarthome/guiinfo/ISystemHealthHUD.h
+++ b/xbmc/smarthome/guiinfo/ISystemHealthHUD.h
@@ -71,6 +71,17 @@ public:
   virtual float CPUUtilization(const std::string& systemName) = 0;
 
   /*!
+   * \brief Get the CPU frequency, in Hertz
+   *
+   * The system will be subscribed to if not already subscribed.
+   *
+   * \param systemName The name of the system
+   *
+   * \return The CPU frequency, in Hertz
+   */
+  virtual double CPUFrequencyHz(const std::string& systemName) = 0;
+
+  /*!
    * \brief Get the RAM utilization, as a percent
    *
    * The system will be subscribed to if not already subscribed.

--- a/xbmc/smarthome/guiinfo/SmartHomeGuiInfo.cpp
+++ b/xbmc/smarthome/guiinfo/SmartHomeGuiInfo.cpp
@@ -19,9 +19,32 @@
 
 #include <chrono>
 #include <cmath>
-
 using namespace KODI;
 using namespace SMART_HOME;
+
+namespace
+{
+std::string FormatFrequency(double frequencyHz)
+{
+  if (frequencyHz <= 0.0)
+    return "";
+
+  constexpr double kHz = 1'000.0;
+  constexpr double MHz = 1'000'000.0;
+  constexpr double GHz = 1'000'000'000.0;
+
+  if (frequencyHz >= GHz)
+    return StringUtils::Format("{:.2f} GHz", frequencyHz / GHz);
+
+  if (frequencyHz >= MHz)
+    return StringUtils::Format("{:.1f} MHz", frequencyHz / MHz);
+
+  if (frequencyHz >= kHz)
+    return StringUtils::Format("{:.0f} KHz", frequencyHz / kHz);
+
+  return StringUtils::Format("{:.0f} Hz", frequencyHz);
+}
+} // namespace
 
 CSmartHomeGuiInfo::CSmartHomeGuiInfo(CGUIInfoManager& infoManager,
                                      ISystemHealthHUD& systemHealthHud,
@@ -75,6 +98,17 @@ bool CSmartHomeGuiInfo::GetLabel(std::string& value,
       {
         const float cpuUtilization = m_systemHealthHud.CPUUtilization(systemName);
         value = StringUtils::Format("{} %", static_cast<unsigned int>(std::round(cpuUtilization)));
+        return true;
+      }
+      break;
+    }
+    case SMARTHOME_CPU_FREQUENCY:
+    {
+      const std::string systemName = info.GetData3();
+      if (!systemName.empty())
+      {
+        const double cpuFrequencyHz = m_systemHealthHud.CPUFrequencyHz(systemName);
+        value = FormatFrequency(cpuFrequencyHz);
         return true;
       }
       break;

--- a/xbmc/smarthome/ros2/Ros2SystemHealthManager.cpp
+++ b/xbmc/smarthome/ros2/Ros2SystemHealthManager.cpp
@@ -73,6 +73,18 @@ float CRos2SystemHealthManager::CPUUtilization(const std::string& systemName)
   return it->second.CPUUtilization();
 }
 
+double CRos2SystemHealthManager::CPUFrequencyHz(const std::string& systemName)
+{
+  auto it = m_systemHealths.find(systemName);
+  if (it == m_systemHealths.end())
+  {
+    AddSystem(systemName);
+    it = m_systemHealths.find(systemName);
+  }
+
+  return it->second.CPUFrequencyHz();
+}
+
 float CRos2SystemHealthManager::MemoryUtilization(const std::string& systemName)
 {
   auto it = m_systemHealths.find(systemName);

--- a/xbmc/smarthome/ros2/Ros2SystemHealthManager.h
+++ b/xbmc/smarthome/ros2/Ros2SystemHealthManager.h
@@ -43,6 +43,7 @@ public:
   bool IsActive(const std::string& systemName, std::chrono::milliseconds timeout) override;
   CTemperature CPUTemperature(const std::string& systemName) override;
   float CPUUtilization(const std::string& systemName) override;
+  double CPUFrequencyHz(const std::string& systemName) override;
   float MemoryUtilization(const std::string& systemName) override;
 
 private:

--- a/xbmc/smarthome/ros2/Ros2SystemHealthSubscriber.cpp
+++ b/xbmc/smarthome/ros2/Ros2SystemHealthSubscriber.cpp
@@ -98,6 +98,13 @@ float CRos2SystemHealthSubscriber::CPUUtilization() const
   return m_cpuUtilization;
 }
 
+double CRos2SystemHealthSubscriber::CPUFrequencyHz() const
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  return m_cpuFrequencyHz;
+}
+
 float CRos2SystemHealthSubscriber::MemoryUtilization() const
 {
   std::lock_guard<std::mutex> lock(m_mutex);
@@ -115,5 +122,6 @@ void CRos2SystemHealthSubscriber::OnSystemTelemetry(const SystemTelemetry::Share
   // Update system health parameters
   m_cpuTemperature = CTemperature::CreateFromCelsius(msg->cpu_temperature);
   m_cpuUtilization = msg->cpu_utilization;
+  m_cpuFrequencyHz = msg->cpu_frequency_ghz * 1'000'000'000.0;
   m_memoryUtilization = msg->memory_utilization;
 }

--- a/xbmc/smarthome/ros2/Ros2SystemHealthSubscriber.h
+++ b/xbmc/smarthome/ros2/Ros2SystemHealthSubscriber.h
@@ -43,6 +43,7 @@ public:
   bool IsActive(std::chrono::milliseconds timeout) const;
   CTemperature CPUTemperature() const;
   float CPUUtilization() const;
+  double CPUFrequencyHz() const;
   float MemoryUtilization() const;
 
 private:
@@ -60,6 +61,7 @@ private:
   std::chrono::time_point<std::chrono::steady_clock> m_lastActive;
   CTemperature m_cpuTemperature;
   float m_cpuUtilization{0.0f};
+  double m_cpuFrequencyHz{0.0};
   float m_memoryUtilization{0.0f};
 
   // Synchronization parameters


### PR DESCRIPTION
## Summary
- add a SmartHome System CPUFrequency info label that reports formatted CPU speed
- expose ROS2 system telemetry CPU frequency values through the system health HUD
- show CPU frequency in the station HUD between the system name and CPU percent columns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d75c401384832e924a45ea1bcda9eb