### PR TITLE
Switch ROS2 video subscription to new image_transport API

### DIFF
--- a/xbmc/smarthome/ros2/Ros2VideoSubscription.cpp
+++ b/xbmc/smarthome/ros2/Ros2VideoSubscription.cpp
@@ -21,6 +21,7 @@
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rmw/qos_profiles.h>
 
 extern "C"
 {
@@ -49,23 +50,24 @@ void CRos2VideoSubscription::Initialize()
   // Initialize rendering
   m_renderer->Initialize();
 
-  // Initialize ROS
-  m_imgTransport = std::make_unique<image_transport::ImageTransport>(m_node);
-  m_imgSubscriber = std::make_unique<image_transport::Subscriber>();
-
   const auto transportHints = image_transport::TransportHints(m_node.get(), "compressed");
 
   CLog::Log(LOGDEBUG, "ROS2: Subscribing to {}", m_topic);
 
-  *m_imgSubscriber = m_imgTransport->subscribe(m_topic, 1, &CRos2VideoSubscription::ReceiveImage,
-                                               this, &transportHints);
+  // Initialize ROS subscription
+  rmw_qos_profile_t qos = rmw_qos_profile_default;
+  qos.depth = 1;
+
+  m_imgSubscriber = image_transport::create_subscription(
+      m_node.get(), m_topic,
+      [this](const sensor_msgs::msg::Image::ConstSharedPtr& msg) { ReceiveImage(msg); },
+      transportHints.getTransport(), qos);
 }
 
 void CRos2VideoSubscription::Deinitialize()
 {
   // Deinitialize ROS
-  m_imgSubscriber.reset();
-  m_imgTransport.reset();
+  m_imgSubscriber.shutdown();
 
   // Deinitialize stream
   if (m_stream)

--- a/xbmc/smarthome/ros2/Ros2VideoSubscription.h
+++ b/xbmc/smarthome/ros2/Ros2VideoSubscription.h
@@ -16,11 +16,6 @@
 
 struct SwsContext;
 
-namespace image_transport
-{
-class ImageTransport;
-}
-
 namespace rclcpp
 {
 class Node;
@@ -60,8 +55,7 @@ private:
   const std::string m_topic;
 
   // ROS parameters
-  std::unique_ptr<image_transport::ImageTransport> m_imgTransport;
-  std::unique_ptr<image_transport::Subscriber> m_imgSubscriber;
+  image_transport::Subscriber m_imgSubscriber;
 
   // Smart home parameters
   std::unique_ptr<CSmartHomeStreamManager> m_streamManager;


### PR DESCRIPTION
## Summary
- replace the ROS image transport helper with the new free-function subscription API
- preserve the previous queue depth via an explicit QoS profile and keep the compressed transport
- clean up shutdown by releasing the subscriber directly

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918b98b5f0c832e996b5a3f64a96e5f)