### PR TITLE
Fix digest creation timestamp parsing

### DIFF
--- a/xbmc/games/agents/input/AgentTopologyXML.cpp
+++ b/xbmc/games/agents/input/AgentTopologyXML.cpp
@@ -94,7 +94,7 @@ bool CAgentTopologyXML::DeserializeTopology(const tinyxml2::XMLElement& topology
   if (digestCreation != nullptr)
   {
     CDateTime digestCreationUtc;
-    if (!digestCreationUtc.SetFromW3CDateTime(digestCreation, false))
+    if (!digestCreationUtc.SetFromW3CDateTime(digestCreation, true))
     {
       CLog::Log(LOGERROR, "Invalid attribute \"{}\": \"{}\"", XML_ATTR_DIGTEST_CREATION,
                 digestCreation);


### PR DESCRIPTION
### Motivation
- A round-trip equality failure in `TestAgentInputMapXML::SerializeDeserializeTopology` indicated the digest creation timestamp was being adjusted during parsing, altering the UTC value.

### Description
- Parse the `digestcreation` attribute as UTC by calling `SetFromW3CDateTime(..., true)` in `xbmc/games/agents/input/AgentTopologyXML.cpp` to avoid timezone adjustment and preserve the original timestamp.

### Testing
- No automated tests were run on the modified code after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e01c70ff083269f5485b6db877ca5)