### PR TITLE
Fix digest timestamp precision in agent topologies

### DIFF
--- a/xbmc/games/agents/input/AgentTopology.cpp
+++ b/xbmc/games/agents/input/AgentTopology.cpp
@@ -32,8 +32,13 @@ void CAgentTopology::UpdateDigest()
     std::string strDigest = m_controllerTree->GetDigest(UTILITY::CDigest::Type::SHA256);
     m_digest = StringUtils::ToHexadecimal(strDigest);
 
-    // Take a timestamp of the system clock
+    // Take a timestamp of the system clock and truncate to whole seconds so it survives XML
+    // round-tripping (W3C date time strings don't include sub-second precision).
     m_digestCreationUtc = CDateTime::GetUTCDateTime();
+    KODI::TIME::SystemTime systemTime{};
+    m_digestCreationUtc.GetAsSystemTime(systemTime);
+    systemTime.milliseconds = 0;
+    m_digestCreationUtc = CDateTime(systemTime);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Fix a serialization mismatch where `GetDigestCreationUTC()` lost sub-second precision when converted to W3C date-time strings causing `SerializeDeserializeTopology` to fail by producing unequal `CDateTime` values.

### Description
- In `xbmc/games/agents/input/AgentTopology.cpp` `CAgentTopology::UpdateDigest()` the UTC timestamp is now truncated to whole seconds by converting to `KODI::TIME::SystemTime`, zeroing `milliseconds` and reconstructing a `CDateTime`, so the stored digest creation time survives XML round-trips.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e01c70ff083269f5485b6db877ca5)