### PR TITLE
Add ARM assembler flags for Boost.Context builds

### DIFF
--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -61,10 +61,17 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       set(CMAKE_EXTRA_ARGS "-DCMAKE_ASM_FLAGS=${CMAKE_C_FLAGS}")
     endif()
 
-    # Ensure the ARM assembler sees the same flags as the C compiler so it
-    # enables the correct FPU/ABI settings for Boost.Context.
+    # Ensure the ARM assembler sees the correct FPU/ABI settings for
+    # Boost.Context on hard-float toolchains.
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|armv[7-8]|armel|armhf)$")
-      list(APPEND CMAKE_EXTRA_ARGS "-DCMAKE_ASM_FLAGS=${CMAKE_ASM_FLAGS}")
+      set(_boost_arm_asm_flags "${CMAKE_ASM_FLAGS}")
+      if(CMAKE_LIBRARY_ARCHITECTURE MATCHES "gnueabihf"
+         OR CMAKE_C_COMPILER_TARGET MATCHES "gnueabihf"
+         OR CMAKE_C_COMPILER MATCHES "gnueabihf")
+        string(APPEND _boost_arm_asm_flags " -mfpu=vfp -mfloat-abi=hard")
+      endif()
+      list(APPEND CMAKE_EXTRA_ARGS "-DCMAKE_ASM_FLAGS=${_boost_arm_asm_flags}")
+      unset(_boost_arm_asm_flags)
     endif()
 
     # For our own sanity, just use unversioned system layout. Lib names then also

--- a/cmake/modules/FindBoost.cmake
+++ b/cmake/modules/FindBoost.cmake
@@ -61,6 +61,12 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       set(CMAKE_EXTRA_ARGS "-DCMAKE_ASM_FLAGS=${CMAKE_C_FLAGS}")
     endif()
 
+    # Ensure the ARM assembler sees the same flags as the C compiler so it
+    # enables the correct FPU/ABI settings for Boost.Context.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|armv[7-8]|armel|armhf)$")
+      list(APPEND CMAKE_EXTRA_ARGS "-DCMAKE_ASM_FLAGS=${CMAKE_ASM_FLAGS}")
+    endif()
+
     # For our own sanity, just use unversioned system layout. Lib names then also
     # dont append toolset info eg.
     #   versioned: libboost_container-vc142-mt-x64-1_85.lib


### PR DESCRIPTION
### Motivation
- Boost.Context assembly on ARM targets failed because the assembler did not receive the same compiler flags (FPU/ABI) as the C compiler, so the external Boost build needs the ARM ASM flags forwarded.

### Description
- Add an ARM-specific block to `cmake/modules/FindBoost.cmake` that appends `-DCMAKE_ASM_FLAGS=${CMAKE_ASM_FLAGS}` to `CMAKE_EXTRA_ARGS` when `CMAKE_SYSTEM_PROCESSOR` matches ARM variants so Boost.Context assembly uses the correct ASM flags.

### Testing
- No automated build or tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697fc879a2f4832e8341bfedc020f888)