### PR TITLE
RetroPlayer: add DMA-BUF import prober with non-copy allocator fallback

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -11,10 +11,21 @@
 #include "ServiceBroker.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.h"
 #include "utils/BufferObject.h"
+#if defined(HAVE_LINUX_DMA_HEAP)
+#include "utils/DMAHeapBufferObject.h"
+#endif
+#include "utils/DmaBufImportProber.h"
 #include "utils/EGLImage.h"
+#include "utils/StringUtils.h"
+
+#if defined(HAVE_GBM)
+#include "utils/GBMBufferObject.h"
+#endif
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 #include "windowing/linux/WinSystemEGL.h"
+
+#include <optional>
 
 using namespace KODI;
 using namespace RETRO;
@@ -32,7 +43,9 @@ CRenderBufferDMA::CRenderBufferDMA(CRenderContext& context, int fourcc)
                              "a build misconfiguration as DMA can only be used with EGL and "
                              "specifically platforms that implement CWinSystemEGL");
 
-  m_egl = std::make_unique<CEGLImage>(winSystemEGL->GetEGLDisplay());
+  const EGLDisplay eglDisplay = winSystemEGL->GetEGLDisplay();
+  m_egl = std::make_unique<CEGLImage>(eglDisplay);
+  m_prober = std::make_unique<CDmaBufImportProber>(eglDisplay);
 
   CLog::Log(LOGDEBUG, "CRenderBufferDMA: using BufferObject type: {}", m_bo->GetName());
 }
@@ -42,6 +55,20 @@ CRenderBufferDMA::~CRenderBufferDMA()
   DeleteTexture();
 }
 
+CDmaBufImportProber::ProbeKey CRenderBufferDMA::BuildProbeKey(unsigned int width,
+                                                               unsigned int height) const
+{
+  const auto* renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+  const auto* vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+
+  CDmaBufImportProber::ProbeKey key;
+  key.gpu = StringUtils::Format("{}:{}", vendor ? vendor : "unknown", renderer ? renderer : "unknown");
+  key.drmFourcc = m_fourcc;
+  key.widthBucket = width <= 512 ? 512 : (width <= 1024 ? 1024 : (width <= 2048 ? 2048 : 4096));
+  key.heightBucket = height <= 512 ? 512 : (height <= 1024 ? 1024 : (height <= 2048 ? 2048 : 4096));
+  return key;
+}
+
 bool CRenderBufferDMA::Allocate(AVPixelFormat format, unsigned int width, unsigned int height)
 {
   // Initialize IRenderBuffer
@@ -49,16 +76,84 @@ bool CRenderBufferDMA::Allocate(AVPixelFormat format, unsigned int width, unsign
   m_width = width;
   m_height = height;
 
-  m_bo->CreateBufferObject(m_fourcc, m_width, m_height);
+  const auto probeKey = BuildProbeKey(width, height);
 
-#if defined(EGL_EXT_image_dma_buf_import_modifiers)
-  if (!m_egl->SupportsFormatAndModifier(m_fourcc, m_bo->GetModifier()))
+  auto allocateFn = [](CDmaBufImportProber::AllocatorType allocator,
+                       uint32_t drmFourcc,
+                       uint32_t boWidth,
+                       uint32_t boHeight,
+                       uint64_t modifier,
+                       uint32_t strideAlignment) -> std::unique_ptr<IBufferObject> {
+    std::unique_ptr<IBufferObject> bo;
+
+    switch (allocator)
+    {
+      case CDmaBufImportProber::AllocatorType::GBMModifiers:
+      {
+#if defined(HAVE_GBM)
+        auto gbm = std::make_unique<CGBMBufferObject>();
+        if (!gbm->CreateBufferObjectWithModifier(drmFourcc, boWidth, boHeight, modifier))
+          return nullptr;
+        bo = std::move(gbm);
+        break;
+#else
+        return nullptr;
+#endif
+      }
+      case CDmaBufImportProber::AllocatorType::GBMImplicit:
+      {
+#if defined(HAVE_GBM)
+        auto gbm = std::make_unique<CGBMBufferObject>();
+        if (!gbm->CreateBufferObject(drmFourcc, boWidth, boHeight))
+          return nullptr;
+        bo = std::move(gbm);
+        break;
+#else
+        return nullptr;
+#endif
+      }
+      case CDmaBufImportProber::AllocatorType::DMAHeapImplicit:
+      {
+#if defined(HAVE_LINUX_DMA_HEAP)
+        auto dma = std::make_unique<CDMAHeapBufferObject>();
+        if (!dma->CreateBufferObject(drmFourcc, boWidth, boHeight))
+          return nullptr;
+        bo = std::move(dma);
+        break;
+#else
+        return nullptr;
+#endif
+      }
+      case CDmaBufImportProber::AllocatorType::DMAHeapAligned:
+      {
+#if defined(HAVE_LINUX_DMA_HEAP)
+        auto dma = std::make_unique<CDMAHeapBufferObject>();
+        if (!dma->CreateBufferObjectAligned(drmFourcc, boWidth, boHeight, strideAlignment))
+          return nullptr;
+        bo = std::move(dma);
+        break;
+#else
+        return nullptr;
+#endif
+      }
+    }
+
+    return bo;
+  };
+
+  auto probeResult = m_prober->ProbeAndAdapt(probeKey, width, height, m_fourcc, allocateFn,
+                                             true /*prefer linear*/);
+  if (!probeResult.success)
   {
-    CRPRendererDMAUtils::DisableForSession(m_fourcc, m_width, m_height, m_bo->GetModifier(),
-                                           "unsupported EGL dma-buf format/modifier");
+    CRPRendererDMAUtils::DisableForSession(m_fourcc, m_width, m_height, DRM_FORMAT_MOD_INVALID,
+                                           "all non-copy dma-buf import paths failed");
     return false;
   }
-#endif
+
+  m_bo = allocateFn(probeResult.allocator, m_fourcc, m_width, m_height, probeResult.modifier,
+                    probeResult.strideAlignment);
+  if (!m_bo)
+    return false;
 
   return true;
 }
@@ -122,8 +217,13 @@ bool CRenderBufferDMA::UploadTexture()
   if (success)
     m_egl->UploadImage(m_textureTarget);
   else
+  {
+    const auto probeKey = BuildProbeKey(m_width, m_height);
+    m_prober->Invalidate(probeKey);
+
     CRPRendererDMAUtils::DisableForSession(m_fourcc, m_width, m_height, m_bo->GetModifier(),
                                            "eglCreateImageKHR failed");
+  }
 
   m_egl->DestroyImage();
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cores/RetroPlayer/buffers/BaseRenderBuffer.h"
+#include "utils/DmaBufImportProber.h"
 
 #include <memory>
 
@@ -60,7 +61,9 @@ private:
   void DeleteTexture();
 
   std::unique_ptr<CEGLImage> m_egl;
+  std::unique_ptr<CDmaBufImportProber> m_prober;
   std::unique_ptr<IBufferObject> m_bo;
+  CDmaBufImportProber::ProbeKey BuildProbeKey(unsigned int width, unsigned int height) const;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/utils/BufferObjectFactory.cpp
+++ b/xbmc/utils/BufferObjectFactory.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<CBufferObject> CBufferObjectFactory::CreateBufferObject(bool nee
 void CBufferObjectFactory::RegisterBufferObject(
     const std::function<std::unique_ptr<CBufferObject>()>& createFunc)
 {
-  m_bufferObjects.emplace_front(createFunc);
+  m_bufferObjects.emplace_back(createFunc);
 }
 
 void CBufferObjectFactory::ClearBufferObjects()

--- a/xbmc/utils/BufferObjectFactory.cpp
+++ b/xbmc/utils/BufferObjectFactory.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<CBufferObject> CBufferObjectFactory::CreateBufferObject(bool nee
 void CBufferObjectFactory::RegisterBufferObject(
     const std::function<std::unique_ptr<CBufferObject>()>& createFunc)
 {
-  m_bufferObjects.emplace_back(createFunc);
+  m_bufferObjects.emplace_front(createFunc);
 }
 
 void CBufferObjectFactory::ClearBufferObjects()

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -235,8 +235,10 @@ if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_L
   endif()
 
   if(TARGET ${APP_NAME_LC}::EGL)
-    list(APPEND SOURCES EGLImage.cpp)
-    list(APPEND HEADERS EGLImage.h)
+    list(APPEND SOURCES EGLImage.cpp
+                        DmaBufImportProber.cpp)
+    list(APPEND HEADERS EGLImage.h
+                        DmaBufImportProber.h)
   endif()
 
   if(TARGET ${APP_NAME_LC}::LibDRM)

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -98,6 +98,34 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint32_t format, uint32_t width, u
   return CreateBufferObject(width * height * bpp);
 }
 
+
+bool CDMAHeapBufferObject::CreateBufferObjectAligned(uint32_t format,
+                                                     uint32_t width,
+                                                     uint32_t height,
+                                                     uint32_t strideAlignment)
+{
+  uint32_t bpp{1};
+
+  switch (format)
+  {
+    case DRM_FORMAT_ARGB8888:
+      bpp = 4;
+      break;
+    case DRM_FORMAT_ARGB1555:
+    case DRM_FORMAT_RGB565:
+      bpp = 2;
+      break;
+    default:
+      throw std::runtime_error("CDMAHeapBufferObject: pixel format not implemented");
+  }
+
+  const uint32_t rawStride = width * bpp;
+  const uint32_t alignMask = strideAlignment > 0 ? (strideAlignment - 1) : 0;
+  m_stride = strideAlignment > 0 ? ((rawStride + alignMask) & ~alignMask) : rawStride;
+
+  return CreateBufferObject(static_cast<uint64_t>(m_stride) * height);
+}
+
 bool CDMAHeapBufferObject::CreateBufferObject(uint64_t size)
 {
   m_size = size;

--- a/xbmc/utils/DMAHeapBufferObject.h
+++ b/xbmc/utils/DMAHeapBufferObject.h
@@ -26,6 +26,10 @@ public:
   // IBufferObject overrides via CBufferObject
   bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
   bool CreateBufferObject(uint64_t size) override;
+  bool CreateBufferObjectAligned(uint32_t format,
+                                 uint32_t width,
+                                 uint32_t height,
+                                 uint32_t strideAlignment);
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;

--- a/xbmc/utils/DmaBufImportProber.cpp
+++ b/xbmc/utils/DmaBufImportProber.cpp
@@ -1,0 +1,411 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DmaBufImportProber.h"
+
+#include "ServiceBroker.h"
+#include "utils/BufferObject.h"
+#include "utils/DRMHelpers.h"
+#include "utils/EGLUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <array>
+#include <sstream>
+#include <utility>
+
+namespace
+{
+constexpr std::array<EGLint, CDmaBufImportProber::MAX_PLANES> EGL_PLANE_FD = {
+    EGL_DMA_BUF_PLANE0_FD_EXT,
+    EGL_DMA_BUF_PLANE1_FD_EXT,
+    EGL_DMA_BUF_PLANE2_FD_EXT,
+};
+
+constexpr std::array<EGLint, CDmaBufImportProber::MAX_PLANES> EGL_PLANE_OFFSET = {
+    EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+    EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+    EGL_DMA_BUF_PLANE2_OFFSET_EXT,
+};
+
+constexpr std::array<EGLint, CDmaBufImportProber::MAX_PLANES> EGL_PLANE_PITCH = {
+    EGL_DMA_BUF_PLANE0_PITCH_EXT,
+    EGL_DMA_BUF_PLANE1_PITCH_EXT,
+    EGL_DMA_BUF_PLANE2_PITCH_EXT,
+};
+
+#if defined(EGL_EXT_image_dma_buf_import_modifiers)
+constexpr std::array<EGLint, CDmaBufImportProber::MAX_PLANES> EGL_PLANE_MOD_LO = {
+    EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
+    EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
+    EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT,
+};
+
+constexpr std::array<EGLint, CDmaBufImportProber::MAX_PLANES> EGL_PLANE_MOD_HI = {
+    EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
+    EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT,
+    EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT,
+};
+#endif
+
+constexpr uint32_t STRIDE_ALIGNMENT_CONSERVATIVE{256};
+
+std::string AllocatorTypeToString(CDmaBufImportProber::AllocatorType type)
+{
+  switch (type)
+  {
+    case CDmaBufImportProber::AllocatorType::GBMModifiers:
+      return "GBM(modifiers)";
+    case CDmaBufImportProber::AllocatorType::GBMImplicit:
+      return "GBM(implicit)";
+    case CDmaBufImportProber::AllocatorType::DMAHeapImplicit:
+      return "DMA-heap(implicit)";
+    case CDmaBufImportProber::AllocatorType::DMAHeapAligned:
+      return "DMA-heap(aligned)";
+  }
+
+  return "unknown";
+}
+
+CDmaBufImportProber::DmaBufDesc BuildDesc(IBufferObject& bo, uint32_t width, uint32_t height)
+{
+  CDmaBufImportProber::DmaBufDesc desc;
+  desc.width = width;
+  desc.height = height;
+  desc.planes[0].fd = bo.GetFd();
+  desc.planes[0].offset = 0;
+  desc.planes[0].pitch = bo.GetStride();
+  return desc;
+}
+
+} // namespace
+
+bool CDmaBufImportProber::ProbeKey::operator<(const ProbeKey& other) const
+{
+  return std::tie(gpu, drmFourcc, widthBucket, heightBucket) <
+         std::tie(other.gpu, other.drmFourcc, other.widthBucket, other.heightBucket);
+}
+
+CDmaBufImportProber::CDmaBufImportProber(EGLDisplay display)
+    : CDmaBufImportProber(
+          display,
+          {CEGLUtils::GetRequiredProcAddress<PFNEGLCREATEIMAGEKHRPROC>("eglCreateImageKHR"),
+           CEGLUtils::GetRequiredProcAddress<PFNEGLDESTROYIMAGEKHRPROC>("eglDestroyImageKHR"),
+           nullptr,
+           nullptr})
+{
+#if defined(EGL_EXT_image_dma_buf_import_modifiers)
+  if (CEGLUtils::HasExtension(display, "EGL_EXT_image_dma_buf_import_modifiers"))
+  {
+    m_eglQueryDmaBufFormatsEXT =
+        CEGLUtils::GetRequiredProcAddress<PFNEGLQUERYDMABUFFORMATSEXTPROC>(
+            "eglQueryDmaBufFormatsEXT");
+    m_eglQueryDmaBufModifiersEXT =
+        CEGLUtils::GetRequiredProcAddress<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(
+            "eglQueryDmaBufModifiersEXT");
+  }
+#endif
+}
+
+CDmaBufImportProber::CDmaBufImportProber(EGLDisplay display, EGLFunctions eglFunctions)
+  : m_display(display),
+    m_eglCreateImageKHR(eglFunctions.eglCreateImageKHR),
+    m_eglDestroyImageKHR(eglFunctions.eglDestroyImageKHR),
+    m_eglQueryDmaBufFormatsEXT(eglFunctions.eglQueryDmaBufFormatsEXT),
+    m_eglQueryDmaBufModifiersEXT(eglFunctions.eglQueryDmaBufModifiersEXT)
+{
+}
+
+void CDmaBufImportProber::SetDisplay(EGLDisplay display)
+{
+  std::scoped_lock lock(m_mutex);
+
+  if (m_display == display)
+    return;
+
+  m_display = display;
+  m_caps = {};
+  m_knownGood.clear();
+}
+
+void CDmaBufImportProber::RefreshCapabilitiesLocked()
+{
+  if (m_caps.queried)
+    return;
+
+  m_caps.queried = true;
+#if defined(EGL_EXT_image_dma_buf_import_modifiers)
+  m_caps.hasModifiersExt = (m_eglQueryDmaBufFormatsEXT != nullptr && m_eglQueryDmaBufModifiersEXT != nullptr);
+
+  if (!m_caps.hasModifiersExt)
+    return;
+
+  EGLint count = 0;
+  if (m_eglQueryDmaBufFormatsEXT(m_display, 0, nullptr, &count) != EGL_TRUE || count <= 0)
+    return;
+
+  std::vector<EGLint> formats(count);
+  if (m_eglQueryDmaBufFormatsEXT(m_display, count, formats.data(), &count) != EGL_TRUE)
+    return;
+
+  m_caps.formats.reserve(count);
+  for (int i = 0; i < count; ++i)
+  {
+    const uint32_t drmFourcc = static_cast<uint32_t>(formats[i]);
+    m_caps.formats.emplace_back(drmFourcc);
+
+    EGLint modifierCount = 0;
+    if (m_eglQueryDmaBufModifiersEXT(m_display, formats[i], 0, nullptr, nullptr, &modifierCount) != EGL_TRUE ||
+        modifierCount <= 0)
+    {
+      continue;
+    }
+
+    std::vector<EGLuint64KHR> modifiers(modifierCount);
+    std::vector<EGLBoolean> externalOnly(modifierCount);
+    if (m_eglQueryDmaBufModifiersEXT(m_display, formats[i], modifierCount, modifiers.data(),
+                                     externalOnly.data(), &modifierCount) != EGL_TRUE)
+    {
+      continue;
+    }
+
+    auto& list = m_caps.modifiers[drmFourcc];
+    list.reserve(modifierCount);
+    for (int index = 0; index < modifierCount; ++index)
+    {
+      list.push_back(ModifierInfo{static_cast<uint64_t>(modifiers[index]),
+                                  externalOnly[index] == EGL_TRUE});
+    }
+  }
+#endif
+}
+
+std::vector<uint64_t> CDmaBufImportProber::BuildModifierPriority(uint32_t drmFourcc,
+                                                                 bool preferLinear) const
+{
+  std::vector<uint64_t> ordered;
+
+  auto it = m_caps.modifiers.find(drmFourcc);
+  if (it == m_caps.modifiers.end())
+    return ordered;
+
+  for (const auto& mod : it->second)
+  {
+    if (!mod.externalOnly)
+      ordered.push_back(mod.modifier);
+  }
+
+  if (preferLinear)
+  {
+    auto linearIt = std::ranges::find(ordered, DRM_FORMAT_MOD_LINEAR);
+    if (linearIt != ordered.end() && linearIt != ordered.begin())
+    {
+      ordered.erase(linearIt);
+      ordered.insert(ordered.begin(), DRM_FORMAT_MOD_LINEAR);
+    }
+  }
+
+  return ordered;
+}
+
+bool CDmaBufImportProber::TryImportDmaBufAsEGLImage(const DmaBufDesc& desc,
+                                                    uint32_t drmFourcc,
+                                                    uint64_t modifierOrInvalid,
+                                                    EGLImageKHR* outImage,
+                                                    std::string* outError) const
+{
+  if (!m_eglCreateImageKHR || !m_eglDestroyImageKHR)
+  {
+    if (outError)
+      *outError = "missing required EGL image functions";
+    return false;
+  }
+
+  std::vector<EGLint> attributes = {
+      EGL_WIDTH,
+      static_cast<EGLint>(desc.width),
+      EGL_HEIGHT,
+      static_cast<EGLint>(desc.height),
+      EGL_LINUX_DRM_FOURCC_EXT,
+      static_cast<EGLint>(drmFourcc),
+  };
+
+  for (size_t plane = 0; plane < desc.planes.size(); ++plane)
+  {
+    if (desc.planes[plane].fd < 0)
+      continue;
+
+    attributes.insert(attributes.end(),
+                      {EGL_PLANE_FD[plane], desc.planes[plane].fd, EGL_PLANE_OFFSET[plane],
+                       static_cast<EGLint>(desc.planes[plane].offset), EGL_PLANE_PITCH[plane],
+                       static_cast<EGLint>(desc.planes[plane].pitch)});
+
+#if defined(EGL_EXT_image_dma_buf_import_modifiers)
+    if (modifierOrInvalid != DRM_FORMAT_MOD_INVALID)
+    {
+      attributes.insert(attributes.end(), {EGL_PLANE_MOD_LO[plane],
+                                           static_cast<EGLint>(modifierOrInvalid & 0xffffffff),
+                                           EGL_PLANE_MOD_HI[plane],
+                                           static_cast<EGLint>(modifierOrInvalid >> 32)});
+    }
+#endif
+  }
+
+  attributes.push_back(EGL_NONE);
+
+  EGLImageKHR image =
+      m_eglCreateImageKHR(m_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes.data());
+  if (!image)
+  {
+    const EGLint eglError = eglGetError();
+
+    std::ostringstream attrDump;
+    for (size_t index = 0; index + 1 < attributes.size() && attributes[index] != EGL_NONE; index += 2)
+      attrDump << StringUtils::Format("attr={} value={}\n", attributes[index], attributes[index + 1]);
+
+    CLog::Log(LOGDEBUG,
+              "CDmaBufImportProber::{} import failed, fourcc={} modifier={} error={:#4x} attrs:\n{}",
+              __FUNCTION__, DRMHELPERS::FourCCToString(drmFourcc),
+              DRMHELPERS::ModifierToString(modifierOrInvalid), eglError, attrDump.str());
+
+    if (outError)
+      *outError = StringUtils::Format("eglCreateImageKHR failed: {:#4x}", eglError);
+
+    return false;
+  }
+
+  if (outImage)
+    *outImage = image;
+  else
+    m_eglDestroyImageKHR(m_display, image);
+
+  return true;
+}
+
+std::optional<CDmaBufImportProber::ProbeResult>
+CDmaBufImportProber::FindKnownGoodLocked(const ProbeKey& key) const
+{
+  auto it = m_knownGood.find(key);
+  if (it == m_knownGood.end())
+    return std::nullopt;
+
+  return it->second;
+}
+
+void CDmaBufImportProber::StoreKnownGoodLocked(const ProbeKey& key, const ProbeResult& result)
+{
+  if (result.success)
+    m_knownGood[key] = result;
+}
+
+CDmaBufImportProber::ProbeResult CDmaBufImportProber::ProbeAndAdapt(const ProbeKey& key,
+                                                                     uint32_t width,
+                                                                     uint32_t height,
+                                                                     uint32_t drmFourcc,
+                                                                     const AllocateFn& allocateFn,
+                                                                     bool preferLinear)
+{
+  ProbeResult result;
+
+  {
+    std::scoped_lock lock(m_mutex);
+    RefreshCapabilitiesLocked();
+
+    if (auto cached = FindKnownGoodLocked(key); cached.has_value())
+      return cached.value();
+  }
+
+  const auto tryAllocator = [&](AllocatorType type, uint64_t modifier, bool explicitModifier,
+                                uint32_t strideAlignment) -> bool {
+    auto bo = allocateFn(type, drmFourcc, width, height, modifier, strideAlignment);
+    if (!bo)
+      return false;
+
+    auto desc = BuildDesc(*bo, width, height);
+    EGLImageKHR image{nullptr};
+    std::string error;
+
+    const uint64_t importModifier = explicitModifier ? modifier : DRM_FORMAT_MOD_INVALID;
+    if (!TryImportDmaBufAsEGLImage(desc, drmFourcc, importModifier, &image, &error))
+      return false;
+
+    m_eglDestroyImageKHR(m_display, image);
+
+    result.success = true;
+    result.allocator = type;
+    result.modifier = modifier;
+    result.explicitModifier = explicitModifier;
+    result.strideAlignment = strideAlignment;
+    return true;
+  };
+
+  std::vector<uint64_t> prioritizedModifiers;
+  {
+    std::scoped_lock lock(m_mutex);
+    prioritizedModifiers = BuildModifierPriority(drmFourcc, preferLinear);
+  }
+
+  for (uint64_t modifier : prioritizedModifiers)
+  {
+    // Path A: GBM modifier allocation and explicit import to avoid implicit-modifier ambiguity.
+    if (tryAllocator(AllocatorType::GBMModifiers, modifier, true, 0))
+      break;
+  }
+
+  // Path B: GBM without explicit modifiers, lets EGL/driver resolve implicit layout.
+  if (!result.success)
+    tryAllocator(AllocatorType::GBMImplicit, DRM_FORMAT_MOD_INVALID, false, 0);
+
+  // Path C: DMA-heap with implicit modifier import.
+  if (!result.success)
+    tryAllocator(AllocatorType::DMAHeapImplicit, DRM_FORMAT_MOD_INVALID, false, 0);
+
+  // Path D: DMA-heap with conservative stride alignment requirement to satisfy stricter importers.
+  if (!result.success)
+    tryAllocator(AllocatorType::DMAHeapAligned, DRM_FORMAT_MOD_INVALID, false,
+                 STRIDE_ALIGNMENT_CONSERVATIVE);
+
+  if (result.success)
+  {
+    std::scoped_lock lock(m_mutex);
+    StoreKnownGoodLocked(key, result);
+
+    CLog::Log(LOGDEBUG,
+              "CDmaBufImportProber::{} selected {} for fourcc={} buckets={}x{} modifier={}"
+              " explicitModifier={} strideAlignment={}",
+              __FUNCTION__, AllocatorTypeToString(result.allocator), DRMHELPERS::FourCCToString(drmFourcc),
+              key.widthBucket, key.heightBucket, DRMHELPERS::ModifierToString(result.modifier),
+              result.explicitModifier, result.strideAlignment);
+  }
+  else
+  {
+    result.error = "all non-copy DMA import paths failed";
+  }
+
+  return result;
+}
+
+
+void CDmaBufImportProber::SetCapabilityCacheForTest(
+    const std::vector<uint32_t>& formats,
+    const std::map<uint32_t, std::vector<ModifierInfo>>& modifiers,
+    bool hasModifiersExtension)
+{
+  std::scoped_lock lock(m_mutex);
+  m_caps.queried = true;
+  m_caps.hasModifiersExt = hasModifiersExtension;
+  m_caps.formats = formats;
+  m_caps.modifiers = modifiers;
+}
+
+void CDmaBufImportProber::Invalidate(const ProbeKey& key)
+{
+  std::scoped_lock lock(m_mutex);
+  m_knownGood.erase(key);
+}

--- a/xbmc/utils/DmaBufImportProber.h
+++ b/xbmc/utils/DmaBufImportProber.h
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "system_egl.h"
+
+#include <array>
+
+#include <drm_fourcc.h>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+class IBufferObject;
+
+class CDmaBufImportProber
+{
+public:
+  static constexpr int MAX_PLANES{3};
+
+  enum class AllocatorType
+  {
+    GBMModifiers,
+    GBMImplicit,
+    DMAHeapImplicit,
+    DMAHeapAligned,
+  };
+
+  struct DmaBufPlane
+  {
+    int fd{-1};
+    uint32_t offset{0};
+    uint32_t pitch{0};
+  };
+
+  struct DmaBufDesc
+  {
+    uint32_t width{0};
+    uint32_t height{0};
+    std::array<DmaBufPlane, MAX_PLANES> planes;
+  };
+
+  struct ModifierInfo
+  {
+    uint64_t modifier{DRM_FORMAT_MOD_INVALID};
+    bool externalOnly{false};
+  };
+
+  struct EGLFunctions
+  {
+    PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR{nullptr};
+    PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR{nullptr};
+    PFNEGLQUERYDMABUFFORMATSEXTPROC eglQueryDmaBufFormatsEXT{nullptr};
+    PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT{nullptr};
+  };
+
+  struct ProbeResult
+  {
+    bool success{false};
+    AllocatorType allocator{AllocatorType::DMAHeapImplicit};
+    uint64_t modifier{DRM_FORMAT_MOD_INVALID};
+    bool explicitModifier{false};
+    uint32_t strideAlignment{0};
+    std::string error;
+  };
+
+  struct ProbeKey
+  {
+    std::string gpu;
+    uint32_t drmFourcc{0};
+    uint32_t widthBucket{0};
+    uint32_t heightBucket{0};
+
+    bool operator<(const ProbeKey& other) const;
+  };
+
+  using AllocateFn = std::function<std::unique_ptr<IBufferObject>(AllocatorType,
+                                                                   uint32_t drmFourcc,
+                                                                   uint32_t width,
+                                                                   uint32_t height,
+                                                                   uint64_t modifier,
+                                                                   uint32_t strideAlignment)>;
+
+  explicit CDmaBufImportProber(EGLDisplay display);
+  CDmaBufImportProber(EGLDisplay display, EGLFunctions eglFunctions);
+
+  void SetDisplay(EGLDisplay display);
+
+  bool TryImportDmaBufAsEGLImage(const DmaBufDesc& desc,
+                                 uint32_t drmFourcc,
+                                 uint64_t modifierOrInvalid,
+                                 EGLImageKHR* outImage,
+                                 std::string* outError) const;
+
+  ProbeResult ProbeAndAdapt(const ProbeKey& key,
+                            uint32_t width,
+                            uint32_t height,
+                            uint32_t drmFourcc,
+                            const AllocateFn& allocateFn,
+                            bool preferLinear);
+
+  void Invalidate(const ProbeKey& key);
+
+  void SetCapabilityCacheForTest(const std::vector<uint32_t>& formats,
+                                 const std::map<uint32_t, std::vector<ModifierInfo>>& modifiers,
+                                 bool hasModifiersExtension);
+
+private:
+  struct CapabilityCache
+  {
+    bool queried{false};
+    bool hasModifiersExt{false};
+    std::vector<uint32_t> formats;
+    std::map<uint32_t, std::vector<ModifierInfo>> modifiers;
+  };
+
+  void RefreshCapabilitiesLocked();
+  std::vector<uint64_t> BuildModifierPriority(uint32_t drmFourcc, bool preferLinear) const;
+  std::optional<ProbeResult> FindKnownGoodLocked(const ProbeKey& key) const;
+  void StoreKnownGoodLocked(const ProbeKey& key, const ProbeResult& result);
+
+  EGLDisplay m_display{EGL_NO_DISPLAY};
+  PFNEGLCREATEIMAGEKHRPROC m_eglCreateImageKHR{nullptr};
+  PFNEGLDESTROYIMAGEKHRPROC m_eglDestroyImageKHR{nullptr};
+
+  PFNEGLQUERYDMABUFFORMATSEXTPROC m_eglQueryDmaBufFormatsEXT{nullptr};
+  PFNEGLQUERYDMABUFMODIFIERSEXTPROC m_eglQueryDmaBufModifiersEXT{nullptr};
+
+  mutable std::mutex m_mutex;
+  CapabilityCache m_caps;
+  std::map<ProbeKey, ProbeResult> m_knownGood;
+};
+

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -57,6 +57,30 @@ bool CGBMBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint3
   return true;
 }
 
+
+bool CGBMBufferObject::CreateBufferObjectWithModifier(uint32_t format,
+                                                      uint32_t width,
+                                                      uint32_t height,
+                                                      uint64_t modifier)
+{
+#if defined(HAS_GBM_MODIFIERS)
+  if (m_fd >= 0)
+    return true;
+
+  m_width = width;
+  m_height = height;
+
+  const uint64_t modifiers[] = {modifier};
+  m_bo = gbm_bo_create_with_modifiers(m_device, m_width, m_height, format, modifiers, 1);
+  if (!m_bo)
+    return false;
+
+  m_fd = gbm_bo_get_fd(m_bo);
+  return m_fd >= 0;
+#else
+  return false;
+#endif
+}
 void CGBMBufferObject::DestroyBufferObject()
 {
   close(m_fd);

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -28,6 +28,10 @@ public:
 
   // IBufferObject overrides via CBufferObject
   bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
+  bool CreateBufferObjectWithModifier(uint32_t format,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      uint64_t modifier);
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES TestAlarmClock.cpp
             TestComponentContainer.cpp
             TestCrc32.cpp
             TestDatabaseUtils.cpp
+            TestDmaBufImportProber.cpp
             TestDigest.cpp
             TestEndianSwap.cpp
             TestExecString.cpp

--- a/xbmc/utils/test/TestDmaBufImportProber.cpp
+++ b/xbmc/utils/test/TestDmaBufImportProber.cpp
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/DmaBufImportProber.h"
+
+#include "utils/IBufferObject.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace
+{
+class CMockBufferObject : public IBufferObject
+{
+public:
+  explicit CMockBufferObject(uint32_t stride) : m_stride(stride) {}
+
+  bool CreateBufferObject(uint32_t, uint32_t, uint32_t) override { return true; }
+  bool CreateBufferObject(uint64_t) override { return true; }
+  void DestroyBufferObject() override {}
+  uint8_t* GetMemory() override { return nullptr; }
+  void ReleaseMemory() override {}
+  int GetFd() override { return 42; }
+  uint32_t GetStride() override { return m_stride; }
+  uint64_t GetModifier() override { return DRM_FORMAT_MOD_LINEAR; }
+  void SyncStart() override {}
+  void SyncEnd() override {}
+  std::string GetName() const override { return "mock"; }
+
+private:
+  uint32_t m_stride{0};
+};
+
+EGLImageKHR FakeCreateImage(EGLDisplay,
+                            EGLContext,
+                            EGLenum,
+                            EGLClientBuffer,
+                            const EGLint*)
+{
+  static int callCount = 0;
+  ++callCount;
+
+  // First two imports fail (GBM with modifier, then GBM implicit), third succeeds (DMA-heap implicit).
+  return callCount >= 3 ? reinterpret_cast<EGLImageKHR>(0x1) : nullptr;
+}
+
+EGLBoolean FakeDestroyImage(EGLDisplay, EGLImageKHR)
+{
+  return EGL_TRUE;
+}
+
+} // namespace
+
+// Verifies the deterministic retry order and selection of the first successful non-copy path.
+TEST(TestDmaBufImportProber, RetrySequenceSelectsDMAHeapImplicit)
+{
+  CDmaBufImportProber::EGLFunctions eglFunctions{};
+  eglFunctions.eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(FakeCreateImage);
+  eglFunctions.eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(FakeDestroyImage);
+
+  CDmaBufImportProber prober(EGL_NO_DISPLAY, eglFunctions);
+  prober.SetCapabilityCacheForTest({DRM_FORMAT_RGB565},
+                                   {{DRM_FORMAT_RGB565,
+                                     {{DRM_FORMAT_MOD_LINEAR, false}}}},
+                                   true);
+
+  std::vector<CDmaBufImportProber::AllocatorType> attempts;
+
+  auto result = prober.ProbeAndAdapt(
+      {.gpu = "testgpu", .drmFourcc = DRM_FORMAT_RGB565, .widthBucket = 512, .heightBucket = 512},
+      320, 240, DRM_FORMAT_RGB565,
+      [&](CDmaBufImportProber::AllocatorType allocator,
+          uint32_t,
+          uint32_t,
+          uint32_t,
+          uint64_t,
+          uint32_t) -> std::unique_ptr<IBufferObject> {
+        attempts.push_back(allocator);
+        return std::make_unique<CMockBufferObject>(640);
+      },
+      true);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_EQ(result.allocator, CDmaBufImportProber::AllocatorType::DMAHeapImplicit);
+  ASSERT_GE(attempts.size(), 3U);
+  EXPECT_EQ(attempts[0], CDmaBufImportProber::AllocatorType::GBMModifiers);
+  EXPECT_EQ(attempts[1], CDmaBufImportProber::AllocatorType::GBMImplicit);
+  EXPECT_EQ(attempts[2], CDmaBufImportProber::AllocatorType::DMAHeapImplicit);
+}


### PR DESCRIPTION
### Motivation
- Some EGL drivers reject specific dmabuf layouts/modifiers (causing `eglCreateImageKHR` failures) even though a zero-copy path exists with a different allocator or modifier, so RetroPlayer should probe and adapt rather than immediately falling back to a CPU copy path. 
- The goal is a cheap, cached "probe-and-adapt" policy that finds a working dmabuf → EGLImage → GL texture path using GBM and DMA-heap allocators without introducing per-frame probing or render-thread stalls.

### Description
- Add a new `CDmaBufImportProber` utility (header + implementation) that discovers and caches per-`EGLDisplay` DMA-BUF capabilities and modifiers via `eglQueryDmaBufFormatsEXT` / `eglQueryDmaBufModifiersEXT`, exposes `TryImportDmaBufAsEGLImage(...)`, and provides `ProbeAndAdapt(...)` which tries allocator paths in order: `GBM + modifier`, `GBM implicit`, `DMA-heap implicit`, `DMA-heap aligned`.
- Provide a small probe API and result type: `ProbeResult` contains chosen `AllocatorType`, `modifier`, `explicitModifier` flag, `strideAlignment`, and error text; keyed caching uses `(gpu renderer string, drm_fourcc, width bucket, height bucket)` with `Invalidate(...)` on runtime failures.
- Integrate the prober into RetroPlayer by updating `CRenderBufferDMA::Allocate()` to call the prober (injecting an `allocateFn` lambda that instantiates `CGBMBufferObject` / `CDMAHeapBufferObject` variants) and by invalidating the cached probe entry in `UploadTexture()` if `eglCreateImageKHR` fails at runtime.
- Extend allocator helpers to avoid copies: add `CGBMBufferObject::CreateBufferObjectWithModifier(...)` and `CDMAHeapBufferObject::CreateBufferObjectAligned(...)` and conditionally compile them behind existing feature macros so the probe can exercise those paths safely.
- Add unit-testable seams: an injectable `EGLFunctions` table (mock `eglCreateImageKHR`/`eglDestroyImageKHR`/query procs) and `SetCapabilityCacheForTest(...)` to inject deterministic capability sets; include a deterministic test `TestDmaBufImportProber` that verifies the retry order and first-success selection logic.
- Wire the new prober into `xbmc/utils/CMakeLists.txt` and add the test to `utils_test` CMake inputs.

### Testing
- Ran `git diff --check` to validate patch formatting (succeeded).
- Attempted to configure/build (`cmake -S . -B build -G Ninja -DAPP_RENDER_SYSTEM=gl -DENABLE_INTERNAL_FFMPEG=ON`) but configure failed in this environment due to a missing `UDEV` dependency; as a result `utils_test` was not built or executed here.
- Added a deterministic unit test `TestDmaBufImportProber` (mocking `eglCreateImageKHR`) that exercises the probe retry order and allocator selection; the test is included in the `utils_test` suite and is runnable in a host environment with the normal build dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5a71990083269304fa4846fa8897)