### PR TITLE
games: preserve removed tombstones when merging disc slots

### DIFF
--- a/xbmc/games/addons/disc/CMakeLists.txt
+++ b/xbmc/games/addons/disc/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES GameClientDiscModel.cpp
+            GameClientDiscMergeUtils.cpp
             GameClientDiscs.cpp
             GameClientDiscTransport.cpp
             GameClientDiscXML.cpp
 )
 
 set(HEADERS GameClientDiscModel.h
+            GameClientDiscMergeUtils.h
             GameClientDiscs.h
             GameClientDiscTransport.h
             GameClientDiscXML.h

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GameClientDiscMergeUtils.h"
+
+#include <algorithm>
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+bool ShouldPreserveRemovedTombstone(const GameClientDiscEntry& previousDisc,
+                                    const GameClientDiscEntry& coreDisc)
+{
+  return previousDisc.slotType == GameClientDiscEntry::DiscSlotType::RemovedSlot &&
+         coreDisc.slotType == GameClientDiscEntry::DiscSlotType::EmptySlot;
+}
+} // namespace
+
+bool KODI::GAME::IsSelectableDiscSlot(const GameClientDiscEntry& discEntry)
+{
+  return discEntry.slotType != GameClientDiscEntry::DiscSlotType::RemovedSlot;
+}
+
+MergedDiscSlots KODI::GAME::MergeCoreSlotsByIndex(const std::vector<GameClientDiscEntry>& previousDiscs,
+                                                  const std::vector<GameClientDiscEntry>& coreDiscs)
+{
+  MergedDiscSlots merged;
+  merged.coreToMerged.resize(coreDiscs.size());
+  merged.discs.reserve(std::max(previousDiscs.size(), coreDiscs.size()));
+
+  const size_t overlapCount = std::min(previousDiscs.size(), coreDiscs.size());
+  for (size_t i = 0; i < overlapCount; ++i)
+  {
+    if (ShouldPreserveRemovedTombstone(previousDiscs[i], coreDiscs[i]))
+    {
+      merged.discs.push_back(previousDiscs[i]);
+      continue;
+    }
+
+    merged.discs.push_back(coreDiscs[i]);
+    merged.coreToMerged[i] = i;
+  }
+
+  for (size_t i = overlapCount; i < previousDiscs.size(); ++i)
+  {
+    if (previousDiscs[i].slotType == GameClientDiscEntry::DiscSlotType::RemovedSlot)
+      merged.discs.push_back(previousDiscs[i]);
+  }
+
+  for (size_t i = overlapCount; i < coreDiscs.size(); ++i)
+  {
+    merged.coreToMerged[i] = merged.discs.size();
+    merged.discs.push_back(coreDiscs[i]);
+  }
+
+  for (size_t i = 0; i < merged.discs.size(); ++i)
+  {
+    if (IsSelectableDiscSlot(merged.discs[i]))
+    {
+      merged.firstSelectable = i;
+      break;
+    }
+  }
+
+  return merged;
+}
+

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "games/addons/disc/GameClientDiscModel.h"
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace KODI
+{
+namespace GAME
+{
+
+struct MergedDiscSlots
+{
+  std::vector<GameClientDiscEntry> discs;
+  std::vector<std::optional<size_t>> coreToMerged;
+  std::optional<size_t> firstSelectable;
+};
+
+bool IsSelectableDiscSlot(const GameClientDiscEntry& discEntry);
+MergedDiscSlots MergeCoreSlotsByIndex(const std::vector<GameClientDiscEntry>& previousDiscs,
+                                      const std::vector<GameClientDiscEntry>& coreDiscs);
+
+} // namespace GAME
+} // namespace KODI
+

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -10,11 +10,11 @@
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
 #include "games/addons/GameClient.h"
+#include "games/addons/disc/GameClientDiscMergeUtils.h"
 #include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscTransport.h"
 
 #include <optional>
-#include <vector>
 
 using namespace KODI;
 using namespace GAME;
@@ -206,62 +206,28 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 
 void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel)
 {
-  const std::vector<GameClientDiscEntry>& previousDiscs = m_discModel->GetDiscs();
-  const std::vector<GameClientDiscEntry>& coreDiscs = coreModel.GetDiscs();
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());
 
-  std::vector<GameClientDiscEntry> mergedDiscs(
-      previousDiscs.size(), {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""});
+  m_discModel->SetDiscs(merged.discs);
 
-  std::vector<size_t> coreToMerged(coreDiscs.size());
-  size_t corePosition = 0;
+  if (!merged.firstSelectable.has_value())
+    return;
 
-  for (size_t i = 0; i < previousDiscs.size(); ++i)
+  m_discModel->SetMainDiscByIndex(*merged.firstSelectable);
+
+  const std::optional<size_t> selectedCoreIndex = coreModel.GetSelectedDiscIndex();
+  if (selectedCoreIndex.has_value() && *selectedCoreIndex < merged.coreToMerged.size())
   {
-    if (previousDiscs[i].slotType == GameClientDiscEntry::DiscSlotType::RemovedSlot)
-      continue;
+    const std::optional<size_t> selectedMergedIndex = merged.coreToMerged[*selectedCoreIndex];
 
-    if (corePosition >= coreDiscs.size())
-      break;
-
-    mergedDiscs[i] = coreDiscs[corePosition];
-    coreToMerged[corePosition] = i;
-    ++corePosition;
-  }
-
-  while (corePosition < coreDiscs.size())
-  {
-    coreToMerged[corePosition] = mergedDiscs.size();
-    mergedDiscs.push_back(coreDiscs[corePosition]);
-    ++corePosition;
-  }
-
-  m_discModel->SetDiscs(mergedDiscs);
-
-  size_t firstSelectable = m_discModel->Size();
-  for (size_t i = 0; i < m_discModel->Size(); ++i)
-  {
-    if (m_discModel->IsSelectableSlotByIndex(i))
+    if (selectedMergedIndex.has_value() && m_discModel->IsSelectableSlotByIndex(*selectedMergedIndex))
     {
-      firstSelectable = i;
-      break;
+      m_discModel->SetLastDiscByIndex(*selectedMergedIndex);
+      m_discModel->SetSelectedDiscByIndex(*selectedMergedIndex);
+      return;
     }
   }
 
-  if (firstSelectable == m_discModel->Size())
-    return;
-
-  m_discModel->SetMainDiscByIndex(firstSelectable);
-
-  const std::optional<size_t> selectedCoreIndex = coreModel.GetSelectedDiscIndex();
-  if (selectedCoreIndex.has_value() && *selectedCoreIndex < coreToMerged.size())
-  {
-    const size_t selectedMergedIndex = coreToMerged[*selectedCoreIndex];
-    m_discModel->SetLastDiscByIndex(selectedMergedIndex);
-    m_discModel->SetSelectedDiscByIndex(selectedMergedIndex);
-  }
-  else
-  {
-    m_discModel->SetLastDiscByIndex(firstSelectable);
-    m_discModel->SetSelectedNoDisc();
-  }
+  m_discModel->SetLastDiscByIndex(*merged.firstSelectable);
+  m_discModel->SetSelectedNoDisc();
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscMergeUtils.h"
 
 #include <gtest/gtest.h>
 
@@ -140,4 +141,106 @@ TEST(TestGameClientDiscModel, MixedSlotModelBehavior)
   EXPECT_EQ(model.GetLabelByIndex(1), "Core Empty");
   EXPECT_EQ(model.GetPathByIndex(2), "");
   EXPECT_EQ(model.GetLabelByIndex(2), "");
+}
+
+TEST(TestGameClientDiscModel, MergePreservesRemovedTombstoneWhenCoreReportsEmpty)
+{
+  std::vector<GameClientDiscEntry> previousDiscs{
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
+
+  std::vector<GameClientDiscEntry> coreDiscs{
+      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Zombie"},
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+}
+
+TEST(TestGameClientDiscModel, MergePreservesGenuineEmptySlotWhenNoRemovedTombstone)
+{
+  std::vector<GameClientDiscEntry> previousDiscs{
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc1.chd", "disc1.chd", ""}};
+
+  std::vector<GameClientDiscEntry> coreDiscs{
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc1.chd", "disc1.chd", ""},
+      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Core Empty"}};
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::EmptySlot);
+  EXPECT_EQ(merged.discs[1].cachedLabel, "Core Empty");
+}
+
+TEST(TestGameClientDiscModel, MergeDoesNotDuplicateRemovedTombstone)
+{
+  std::vector<GameClientDiscEntry> previousDiscs{
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
+
+  std::vector<GameClientDiscEntry> coreDiscs{
+      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Zombie"},
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
+
+  size_t removedCount = 0;
+  size_t discCount = 0;
+  size_t emptyCount = 0;
+
+  for (const auto& disc : merged.discs)
+  {
+    if (disc.slotType == GameClientDiscEntry::DiscSlotType::RemovedSlot)
+      ++removedCount;
+    else if (disc.slotType == GameClientDiscEntry::DiscSlotType::Disc)
+      ++discCount;
+    else
+      ++emptyCount;
+  }
+
+  EXPECT_EQ(removedCount, 1U);
+  EXPECT_EQ(discCount, 1U);
+  EXPECT_EQ(emptyCount, 0U);
+}
+
+TEST(TestGameClientDiscModel, MergeSelectionMappingSkipsRemovedSlot)
+{
+  std::vector<GameClientDiscEntry> previousDiscs{
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
+
+  std::vector<GameClientDiscEntry> coreDiscs{
+      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Zombie"},
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
+
+  ASSERT_TRUE(merged.firstSelectable.has_value());
+  EXPECT_EQ(*merged.firstSelectable, 1U);
+  ASSERT_EQ(merged.coreToMerged.size(), 2U);
+  EXPECT_FALSE(merged.coreToMerged[0].has_value());
+  ASSERT_TRUE(merged.coreToMerged[1].has_value());
+  EXPECT_EQ(*merged.coreToMerged[1], 1U);
+}
+
+TEST(TestGameClientDiscModel, MergePreservesTrailingRemovedSlotsWhenCoreShrinks)
+{
+  std::vector<GameClientDiscEntry> previousDiscs{
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc1.chd", "disc1.chd", ""},
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""}};
+
+  std::vector<GameClientDiscEntry> coreDiscs{
+      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc1.chd", "disc1.chd", ""}};
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
+
+  ASSERT_EQ(merged.discs.size(), 3U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
+  EXPECT_EQ(merged.discs[2].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
 }


### PR DESCRIPTION
### Motivation
- Fix broken- core behavior where a previously-removed tombstone is lost when the core reports the same index as an `EmptySlot`, causing duplicated or shifted logical slots; preserve index-stable tombstones instead.
- Ensure UI selection/main/last semantics continue to avoid landing on `RemovedSlot` entries while keeping genuine core `EmptySlot` values intact.

### Description
- Introduced a small index-based merge utility `MergeCoreSlotsByIndex` in `xbmc/games/addons/disc/GameClientDiscMergeUtils.{h,cpp}` that preserves a previous `RemovedSlot` only when the core reports an `EmptySlot` at the same index, appends trailing core entries when the core grows, and preserves trailing `RemovedSlot` entries when the core shrinks.
- Updated `CGameClientDiscs::MergeCoreModelIntoFrontend()` to use `MergeCoreSlotsByIndex`, set merged discs via `m_discModel->SetDiscs(...)`, and rebuild `main/last/selected` from the explicit `core->merged` mapping while ensuring selections only land on selectable slots (fall back to first selectable + `NoDisc`).
- Kept semantics that `RemovedSlot` is skipped by UI selection and avoided any content/path-based matching or `disc://` synthetic path logic.
- Added focused unit tests in `xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp` that cover tombstone preservation, genuine core empty-slot preservation, no-duplication of removed tombstones, selection mapping skipping removed slots, and preservation of trailing removed slots.
- Wired the new utility into the disc module build (`xbmc/games/addons/disc/CMakeLists.txt`).

### Testing
- Attempted to configure the tree with `cmake -S . -B build -G Ninja` and `cmake -S . -B build -G Ninja -DAPP_RENDER_SYSTEM=gl -DENABLE_UDEV=OFF`, but configuration is blocked in this environment by missing platform dependencies (`UDEV` and render-system selection), so a full build and unit-test run could not be executed.
- Added/updated unit tests under `xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp` to exercise the new merge behavior in isolation (tests compile/run as part of the normal test suite when the project is configured and built).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b00d7d7440832eac4b112a490dbd53)