### PR TITLE
games: persist disc frontend model state to XML

### DIFF
--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -94,8 +94,9 @@ public:
   bool IsRealDiscByIndex(size_t index) const;
   const GameClientDiscEntry* GetDiscByIndex(size_t index) const;
 
-private:
   static std::string DeriveBasename(const std::string& path);
+
+private:
   std::optional<size_t> GetReplacementIndex(size_t removedIndex) const;
 
   std::vector<GameClientDiscEntry> m_discs;

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -5,3 +5,255 @@
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
+
+#include "GameClientDiscXML.h"
+
+#include "URL.h"
+#include "filesystem/Directory.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "utils/Crc32.h"
+#include "utils/FileUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML2.h"
+#include "utils/log.h"
+
+#include <tinyxml2.h>
+
+#include <cstring>
+#include <optional>
+#include <vector>
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+constexpr auto PROFILE_ROOT = "special://masterprofile";
+constexpr auto DISC_STATE_DIRECTORY = "games/discstate";
+constexpr auto XML_ROOT = "discstate";
+constexpr auto XML_SLOTS = "slots";
+constexpr auto XML_SLOT = "slot";
+constexpr auto XML_SELECTED = "selected";
+constexpr auto XML_ATTR_TYPE = "type";
+constexpr auto XML_ATTR_PATH = "path";
+constexpr auto XML_ATTR_LABEL = "label";
+constexpr auto XML_ATTR_INDEX = "index";
+
+constexpr auto TYPE_DISC = "disc";
+constexpr auto TYPE_EMPTY = "empty";
+constexpr auto TYPE_REMOVED = "removed";
+constexpr auto TYPE_NONE = "none";
+
+std::string GetDiscStateDirectory()
+{
+  return URIUtils::AddFileToFolder(PROFILE_ROOT, DISC_STATE_DIRECTORY);
+}
+
+bool IsPersistableDiscPath(const std::string& path)
+{
+  return !path.empty() && !URIUtils::IsProtocol(path, "disc");
+}
+
+std::optional<size_t> GetFirstSelectable(const CGameClientDiscModel& model)
+{
+  for (size_t i = 0; i < model.Size(); ++i)
+  {
+    if (model.IsSelectableSlotByIndex(i))
+      return i;
+  }
+
+  return std::nullopt;
+}
+} // namespace
+
+std::string CGameClientDiscXML::GetXMLPath(const std::string& gamePath)
+{
+  const std::string fileName = StringUtils::Format("{:08x}.xml", Crc32::Compute(gamePath));
+  return URIUtils::AddFileToFolder(GetDiscStateDirectory(), fileName);
+}
+
+bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel& model) const
+{
+  model.Clear();
+
+  if (gamePath.empty())
+    return true;
+
+  const std::string xmlPath = GetXMLPath(gamePath);
+
+  if (!CFileUtils::Exists(xmlPath))
+    return true;
+
+  CXBMCTinyXML2 xmlDoc;
+  if (!xmlDoc.LoadFile(xmlPath))
+  {
+    CLog::Log(LOGWARNING, "Failed to load disc state XML {}: {} at line {}",
+              CURL::GetRedacted(xmlPath), xmlDoc.ErrorStr(), xmlDoc.ErrorLineNum());
+    return false;
+  }
+
+  const tinyxml2::XMLElement* rootElement = xmlDoc.RootElement();
+  if (rootElement == nullptr || std::strcmp(rootElement->Name(), XML_ROOT) != 0)
+  {
+    CLog::Log(LOGWARNING, "Failed to parse disc state XML {}, missing root element '{}'",
+              CURL::GetRedacted(xmlPath), XML_ROOT);
+    model.Clear();
+    return false;
+  }
+
+  std::vector<GameClientDiscEntry> discs;
+
+  const tinyxml2::XMLElement* slotsElement = rootElement->FirstChildElement(XML_SLOTS);
+  const tinyxml2::XMLElement* slotElement = slotsElement != nullptr ? slotsElement->FirstChildElement(XML_SLOT)
+                                                                     : nullptr;
+
+  while (slotElement != nullptr)
+  {
+    const char* type = slotElement->Attribute(XML_ATTR_TYPE);
+    const std::string label = slotElement->Attribute(XML_ATTR_LABEL) != nullptr
+                                  ? slotElement->Attribute(XML_ATTR_LABEL)
+                                  : "";
+
+    if (type != nullptr && std::strcmp(type, TYPE_REMOVED) == 0)
+    {
+      discs.push_back({GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""});
+    }
+    else if (type != nullptr && std::strcmp(type, TYPE_EMPTY) == 0)
+    {
+      discs.push_back({GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", label});
+    }
+    else
+    {
+      const char* path = slotElement->Attribute(XML_ATTR_PATH);
+      if (path != nullptr && IsPersistableDiscPath(path))
+      {
+        discs.push_back({GameClientDiscEntry::DiscSlotType::Disc, path,
+                         CGameClientDiscModel::DeriveBasename(path), label});
+      }
+      else
+      {
+        discs.push_back({GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", label});
+      }
+    }
+
+    slotElement = slotElement->NextSiblingElement(XML_SLOT);
+  }
+
+  model.SetDiscs(discs);
+
+  const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
+  if (firstSelectable.has_value())
+  {
+    model.SetMainDiscByIndex(*firstSelectable);
+    model.SetLastDiscByIndex(*firstSelectable);
+  }
+
+  const tinyxml2::XMLElement* selectedElement = rootElement->FirstChildElement(XML_SELECTED);
+  if (selectedElement != nullptr)
+  {
+    const char* selectedType = selectedElement->Attribute(XML_ATTR_TYPE);
+    if (selectedType != nullptr && std::strcmp(selectedType, TYPE_NONE) == 0)
+    {
+      model.SetSelectedNoDisc();
+    }
+    else
+    {
+      const int selectedIndex = selectedElement->IntAttribute(XML_ATTR_INDEX, -1);
+      if (selectedIndex >= 0 && model.IsRealDiscByIndex(static_cast<size_t>(selectedIndex)))
+        model.SetSelectedDiscByIndex(static_cast<size_t>(selectedIndex));
+      else
+        model.SetSelectedNoDisc();
+    }
+  }
+  else
+  {
+    model.SetSelectedNoDisc();
+  }
+
+  return true;
+}
+
+bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDiscModel& model) const
+{
+  if (gamePath.empty())
+    return true;
+
+  const std::string directory = GetDiscStateDirectory();
+  if (!XFILE::CDirectory::Exists(directory) && !XFILE::CDirectory::Create(directory))
+  {
+    CLog::Log(LOGWARNING, "Failed to create disc state directory {}", CURL::GetRedacted(directory));
+    return false;
+  }
+
+  CXBMCTinyXML2 xmlDoc;
+
+  tinyxml2::XMLElement* rootElement = xmlDoc.NewElement(XML_ROOT);
+  xmlDoc.InsertEndChild(rootElement);
+
+  tinyxml2::XMLElement* slotsElement = xmlDoc.NewElement(XML_SLOTS);
+  rootElement->InsertEndChild(slotsElement);
+
+  for (const GameClientDiscEntry& disc : model.GetDiscs())
+  {
+    tinyxml2::XMLElement* slotElement = xmlDoc.NewElement(XML_SLOT);
+
+    switch (disc.slotType)
+    {
+      case GameClientDiscEntry::DiscSlotType::Disc:
+      {
+        if (IsPersistableDiscPath(disc.path))
+        {
+          slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_DISC);
+          slotElement->SetAttribute(XML_ATTR_PATH, disc.path.c_str());
+        }
+        else
+        {
+          slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_EMPTY);
+        }
+
+        if (!disc.cachedLabel.empty())
+          slotElement->SetAttribute(XML_ATTR_LABEL, disc.cachedLabel.c_str());
+        break;
+      }
+      case GameClientDiscEntry::DiscSlotType::EmptySlot:
+      {
+        slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_EMPTY);
+        if (!disc.cachedLabel.empty())
+          slotElement->SetAttribute(XML_ATTR_LABEL, disc.cachedLabel.c_str());
+        break;
+      }
+      case GameClientDiscEntry::DiscSlotType::RemovedSlot:
+      {
+        slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_REMOVED);
+        break;
+      }
+    }
+
+    slotsElement->InsertEndChild(slotElement);
+  }
+
+  tinyxml2::XMLElement* selectedElement = xmlDoc.NewElement(XML_SELECTED);
+  rootElement->InsertEndChild(selectedElement);
+
+  const std::optional<size_t> selectedIndex = model.GetSelectedDiscIndex();
+  if (selectedIndex.has_value() && model.IsRealDiscByIndex(*selectedIndex) &&
+      IsPersistableDiscPath(model.GetPathByIndex(*selectedIndex)))
+  {
+    selectedElement->SetAttribute(XML_ATTR_TYPE, TYPE_DISC);
+    selectedElement->SetAttribute(XML_ATTR_INDEX, static_cast<unsigned int>(*selectedIndex));
+  }
+  else
+  {
+    selectedElement->SetAttribute(XML_ATTR_TYPE, TYPE_NONE);
+  }
+
+  const std::string xmlPath = GetXMLPath(gamePath);
+  if (!xmlDoc.SaveFile(xmlPath))
+  {
+    CLog::Log(LOGWARNING, "Failed to save disc state XML {}", CURL::GetRedacted(xmlPath));
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/games/addons/disc/GameClientDiscXML.h
+++ b/xbmc/games/addons/disc/GameClientDiscXML.h
@@ -7,3 +7,24 @@
  */
 
 #pragma once
+
+#include <string>
+
+namespace KODI
+{
+namespace GAME
+{
+
+class CGameClientDiscModel;
+
+class CGameClientDiscXML
+{
+public:
+  bool Load(const std::string& gamePath, CGameClientDiscModel& model) const;
+  bool Save(const std::string& gamePath, const CGameClientDiscModel& model) const;
+
+  static std::string GetXMLPath(const std::string& gamePath);
+};
+
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -13,6 +13,7 @@
 #include "games/addons/disc/GameClientDiscMergeUtils.h"
 #include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscTransport.h"
+#include "games/addons/disc/GameClientDiscXML.h"
 
 #include <optional>
 
@@ -24,7 +25,8 @@ CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    CCriticalSection& clientAccess)
   : CGameClientSubsystem(gameClient, addonStruct, clientAccess),
     m_transport(std::make_unique<CGameClientDiscTransport>(gameClient, addonStruct, clientAccess)),
-    m_discModel(std::make_unique<CGameClientDiscModel>())
+    m_discModel(std::make_unique<CGameClientDiscModel>()),
+    m_discXml(std::make_unique<CGameClientDiscXML>())
 {
 }
 
@@ -37,13 +39,15 @@ bool CGameClientDiscs::SupportsDiskControl() const
 
 void CGameClientDiscs::Initialize()
 {
-  //! @todo Restore XML-backed session state if implemented
-  const unsigned int startupIndex = 0;
-  const std::string startupPath;
+  m_discXml->Load(m_gameClient.GetGamePath(), *m_discModel);
 
-  // Restore last-used disc from the XML
-  if (!startupPath.empty())
-    m_transport->SetInitialImage(startupIndex, startupPath);
+  const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
+  if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))
+  {
+    const std::string startupPath = m_discModel->GetPathByIndex(*selectedIndex);
+    if (!startupPath.empty())
+      m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
+  }
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
@@ -54,6 +58,7 @@ void CGameClientDiscs::RefreshDiscState()
   CGameClientDiscModel coreModel;
   BuildModelFromCore(coreModel);
   MergeCoreModelIntoFrontend(coreModel);
+  SaveDiscState();
 }
 
 bool CGameClientDiscs::SetEjected(bool ejected)
@@ -198,6 +203,11 @@ bool CGameClientDiscs::InsertDiscByIndex(size_t index)
 
   RefreshDiscState();
   return true;
+}
+
+void CGameClientDiscs::SaveDiscState()
+{
+  m_discXml->Save(m_gameClient.GetGamePath(), *m_discModel);
 }
 
 void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -26,6 +26,7 @@ namespace GAME
 class CGameClient;
 class CGameClientDiscModel;
 class CGameClientDiscTransport;
+class CGameClientDiscXML;
 
 /*!
  * \ingroup games
@@ -56,9 +57,11 @@ public:
 private:
   void BuildModelFromCore(CGameClientDiscModel& model) const;
   void MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel);
+  void SaveDiscState();
 
   // Add-on parameters
   std::unique_ptr<CGameClientDiscTransport> m_transport;
+  std::unique_ptr<CGameClientDiscXML> m_discXml;
 
   // Game parameters
   std::unique_ptr<CGameClientDiscModel> m_discModel;

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestGameClientDiscModel.cpp
+            TestGameClientDiscXML.cpp
 )
 
 core_add_test_library(test_games_addons_disc)

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/File.h"
+#include "games/addons/disc/GameClientDiscMergeUtils.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscXML.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+constexpr auto GAME_PATH = "/roms/my_game.m3u";
+
+void CleanupStateFile()
+{
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(GAME_PATH));
+}
+} // namespace
+
+TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypesAndLabels)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd", "Disc One"));
+  ASSERT_TRUE(savedModel.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(savedModel.AddRemovedSlot());
+
+  ASSERT_TRUE(savedModel.SetSelectedDiscByIndex(0));
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+
+  ASSERT_EQ(loadedModel.Size(), 3U);
+  EXPECT_TRUE(loadedModel.IsRealDiscByIndex(0));
+  EXPECT_TRUE(loadedModel.IsEmptySlotByIndex(1));
+  EXPECT_TRUE(loadedModel.IsRemovedSlotByIndex(2));
+  EXPECT_EQ(loadedModel.GetPathByIndex(0), "/roms/disc1.chd");
+  EXPECT_EQ(loadedModel.GetLabelByIndex(0), "Disc One");
+  EXPECT_EQ(loadedModel.GetLabelByIndex(1), "Zombie");
+
+  ASSERT_TRUE(loadedModel.GetSelectedDiscIndex().has_value());
+  EXPECT_EQ(*loadedModel.GetSelectedDiscIndex(), 0U);
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, SaveLoadSelectedNonePreserved)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetSelectedNoDisc();
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+
+  EXPECT_TRUE(loadedModel.IsSelectedNoDisc());
+  EXPECT_FALSE(loadedModel.GetSelectedDiscIndex().has_value());
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, MissingXmlIsNonErrorAndLeavesEmptyModel)
+{
+  CleanupStateFile();
+
+  CGameClientDiscXML discXml;
+  CGameClientDiscModel loadedModel;
+
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+  EXPECT_TRUE(loadedModel.Empty());
+}
+
+TEST(TestGameClientDiscXML, MalformedXmlFailsAndClearsModel)
+{
+  CleanupStateFile();
+
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
+
+  XFILE::CFile file;
+  ASSERT_TRUE(file.OpenForWrite(xmlPath, true));
+  static constexpr char malformed[] = "<discstate><slots><slot type=\"disc\"></slots>";
+  ASSERT_EQ(file.Write(malformed, sizeof(malformed) - 1), sizeof(malformed) - 1);
+  file.Close();
+
+  CGameClientDiscXML discXml;
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(loadedModel.AddDisc("/roms/placeholder.chd"));
+
+  EXPECT_FALSE(discXml.Load(GAME_PATH, loadedModel));
+  EXPECT_TRUE(loadedModel.Empty());
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreEmpty)
+{
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(loadedModel.AddRemovedSlot());
+  ASSERT_TRUE(loadedModel.AddDisc("/roms/disc2.chd"));
+
+  CGameClientDiscModel coreModel;
+  ASSERT_TRUE(coreModel.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(coreModel.AddDisc("/roms/disc2.chd"));
+
+  const MergedDiscSlots merged =
+      MergeCoreSlotsByIndex(loadedModel.GetDiscs(), coreModel.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+}


### PR DESCRIPTION
### Motivation
- Persist the frontend disc model across sessions so the UI retains ordered slots, tombstones, empty slots, cached labels and the selected state while keeping existing semantics for errors and synthesized paths.
- Ensure restored frontend state is merged safely with live core state and allow restoring an initial image when supported by transport.

### Description
- Added `CGameClientDiscXML` with `Load`, `Save` and `GetXMLPath` to serialize the frontend model into `special://masterprofile/games/discstate/<crc32>.xml` and to deserialize it back into `CGameClientDiscModel` while defensively handling missing or malformed XML and skipping synthetic `disc://` paths.
- Persisted ordered slots with types `disc`/`empty`/`removed`, disc `path` and `label` (when present), and the selected state as either a `disc` index or explicit `none`; ejected state is not persisted.
- Exposed `DeriveBasename` from `CGameClientDiscModel` to help reconstruct basenames during load without changing existing model semantics.
- Integrated persistence into `CGameClientDiscs` by adding `m_discXml`, loading before merging in `Initialize()` (and calling `SetInitialImage()` for a valid persisted real disc), and saving merged frontend state after `RefreshDiscState()` and after mutating operations via a small `SaveDiscState()` helper.
- Added unit tests `TestGameClientDiscXML.cpp` and wired it into the disc test CMake list to cover save/load roundtrip, selected-none, missing/malformed XML handling, and merge behavior preserving removed tombstones.

### Testing
- Added automated unit tests under `xbmc/games/addons/disc/test/` that exercise XML roundtrip, missing/malformed file handling, and merge interactions, but they were not run due to build configuration constraints in this environment.
- Attempted to configure a test build with `cmake -S . -B build -GNinja -DENABLE_TESTING=ON`, which failed in this container because `APP_RENDER_SYSTEM` must be set and UDEV dependency resolution failed for the chosen platform.
- Attempted a follow-up configure with `-DAPP_RENDER_SYSTEM=gl -DENABLE_UDEV=OFF`, which still failed because the platform configuration enforces UDEV and the dependency is unavailable in the container, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b01aba2040832eb680ed62646b32c5)