### PR TITLE
Restore persisted disc model on startup and preserve when core reports empty

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -213,7 +213,6 @@ bool CGameClient::OpenFile(const CFileItem& file,
   // Some cores "succeed" to load the file even if it doesn't exist
   if (!CFileUtils::Exists(file.GetPath()))
   {
-
     // Failed to play game
     // The required files can't be found.
     MESSAGING::HELPERS::ShowOKDialogText(
@@ -249,7 +248,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
 
   // Initialize disc control subsystem, if supported
   if (SupportsDiscControl())
-    Discs().Initialize();
+    Discs().Initialize(path);
 
   try
   {

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -20,6 +20,18 @@
 using namespace KODI;
 using namespace GAME;
 
+bool HasUsableStartupDisc(const CGameClientDiscModel& model,
+                          std::optional<size_t>& selectedIndex,
+                          std::string& startupPath)
+{
+  selectedIndex = model.GetSelectedDiscIndex();
+  if (!selectedIndex.has_value() || !model.IsRealDiscByIndex(*selectedIndex))
+    return false;
+
+  startupPath = model.GetPathByIndex(*selectedIndex);
+  return !startupPath.empty();
+}
+
 CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    AddonInstance_Game& addonStruct,
                                    CCriticalSection& clientAccess)
@@ -39,15 +51,14 @@ bool CGameClientDiscs::SupportsDiskControl() const
 
 void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
-  m_discXml->Load(gamePath, *m_discModel);
+  CGameClientDiscModel restoredModel;
+  if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
+    *m_discModel = restoredModel;
 
-  const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
-  if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))
-  {
-    const std::string startupPath = m_discModel->GetPathByIndex(*selectedIndex);
-    if (!startupPath.empty())
-      m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
-  }
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(restoredModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
@@ -248,6 +259,9 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 
 void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel)
 {
+  if (coreModel.Empty() && !m_discModel->Empty())
+    return;
+
   const MergedDiscSlots merged =
       MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());
 

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -25,8 +25,8 @@ CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    CCriticalSection& clientAccess)
   : CGameClientSubsystem(gameClient, addonStruct, clientAccess),
     m_transport(std::make_unique<CGameClientDiscTransport>(gameClient, addonStruct, clientAccess)),
-    m_discModel(std::make_unique<CGameClientDiscModel>()),
-    m_discXml(std::make_unique<CGameClientDiscXML>())
+    m_discXml(std::make_unique<CGameClientDiscXML>()),
+    m_discModel(std::make_unique<CGameClientDiscModel>())
 {
 }
 
@@ -37,9 +37,9 @@ bool CGameClientDiscs::SupportsDiskControl() const
   return m_gameClient.SupportsDiscControl();
 }
 
-void CGameClientDiscs::Initialize()
+void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
-  m_discXml->Load(m_gameClient.GetGamePath(), *m_discModel);
+  m_discXml->Load(gamePath, *m_discModel);
 
   const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
   if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -43,7 +43,7 @@ public:
   bool SupportsDiskControl() const;
 
   // Disc interface
-  void Initialize();
+  void Initialize(const std::string& gamePath);
   void RefreshDiscState();
   const CGameClientDiscModel& GetDiscs() const { return *m_discModel; }
   bool IsEjected() const { return m_isEjected; }

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 
 struct AddonInstance_Game;
@@ -27,6 +28,10 @@ class CGameClient;
 class CGameClientDiscModel;
 class CGameClientDiscTransport;
 class CGameClientDiscXML;
+
+bool HasUsableStartupDisc(const CGameClientDiscModel& model,
+                          std::optional<size_t>& selectedIndex,
+                          std::string& startupPath);
 
 /*!
  * \ingroup games

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestGameClientDiscModel.cpp
             TestGameClientDiscXML.cpp
+            TestGameClientDiscs.cpp
 )
 
 core_add_test_library(test_games_addons_disc)

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "games/addons/disc/GameClientDiscMergeUtils.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscs.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+TEST(TestGameClientDiscs, PersistedModelSurvivesEmptyCoreMerge)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  CGameClientDiscModel core;
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[0].path, "/roms/disc1.chd");
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[1].path, "/roms/disc2.chd");
+}
+
+TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+
+  ASSERT_TRUE(HasUsableStartupDisc(persisted, selectedIndex, startupPath));
+  ASSERT_TRUE(selectedIndex.has_value());
+  EXPECT_EQ(*selectedIndex, 1U);
+  EXPECT_EQ(startupPath, "/roms/disc2.chd");
+}
+
+TEST(TestGameClientDiscs, EmptyPersistedAndEmptyCoreRemainEmpty)
+{
+  CGameClientDiscModel persisted;
+  CGameClientDiscModel core;
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  EXPECT_TRUE(merged.discs.empty());
+  EXPECT_FALSE(merged.firstSelectable.has_value());
+}
+
+TEST(TestGameClientDiscs, PersistedAndCoreNonEmptyStillMerge)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddRemovedSlot());
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+
+  CGameClientDiscModel core;
+  ASSERT_TRUE(core.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(core.AddDisc("/roms/disc2.chd"));
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  ASSERT_TRUE(merged.firstSelectable.has_value());
+  EXPECT_EQ(*merged.firstSelectable, 1U);
+}


### PR DESCRIPTION
### Motivation
- Persisted disc XML was being ignored during startup because `Initialize()` only hinted an initial image via `SetInitialImage()` and `RefreshDiscState()` immediately rebuilt from the (possibly empty) core model, causing saved slots to vanish in the UI.
- The goal is to make the saved frontend disc list authoritative at startup until the core provides meaningful data, without changing persistence schema or slot semantics.

### Description
- Load persisted state into a temporary `restoredModel` in `CGameClientDiscs::Initialize()` and copy it into `m_discModel` only when the restored model is non-empty so the frontend sees persisted slots immediately.
- Add helper `HasUsableStartupDisc()` to encapsulate the logic that a selected persisted slot is a real disc with a non-empty path and use it to call `SetInitialImage()` as before.
- Change `MergeCoreModelIntoFrontend()` to treat an empty core model as non-authoritative when the frontend already has data by returning early on `coreModel.Empty() && !m_discModel->Empty()`, preserving persisted slots until the core reports useful slots.
- Add gtest unit coverage in `xbmc/games/addons/disc/test/TestGameClientDiscs.cpp` and register it in the test CMake file to cover persisted vs core empty/merge/startup selection scenarios.

### Testing
- Ran `git diff --check` to validate whitespace/patch correctness and it succeeded.
- Added automated unit tests (`TestGameClientDiscs`) to cover the four requested scenarios, which were added to the test suite but not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0220b6944832ea5f582a669fa3b9e)