### PR TITLE
Persist tray ejected state in discstate XML and restore on startup

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -266,7 +266,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
     return false;
   }
 
-  if (!InitializeGameplay(file.GetPath(), streamManager, input))
+  if (!InitializeGameplay(path, streamManager, input))
   {
     NotifyError(GAME_ERROR_UNKNOWN);
     Streams().Deinitialize();

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -604,6 +604,13 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
     bSuccess = LogError(m_ifc.game->toAddon->Deserialize(m_ifc.game, data, size), "Deserialize()");
   }
 
+  if (bSuccess)
+  {
+    // Deserialization may reset disc information, so restore it now
+    if (SupportsDiscControl())
+      Discs().RestoreDiscList();
+  }
+
   return bSuccess;
 }
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -213,7 +213,6 @@ bool CGameClient::OpenFile(const CFileItem& file,
   // Some cores "succeed" to load the file even if it doesn't exist
   if (!CFileUtils::Exists(file.GetPath()))
   {
-
     // Failed to play game
     // The required files can't be found.
     MESSAGING::HELPERS::ShowOKDialogText(
@@ -249,7 +248,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
 
   // Initialize disc control subsystem, if supported
   if (SupportsDiscControl())
-    Discs().Initialize();
+    Discs().Initialize(path);
 
   try
   {

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
@@ -27,6 +27,7 @@ struct MergedDiscSlots
 };
 
 bool IsSelectableDiscSlot(const GameClientDiscEntry& discEntry);
+
 MergedDiscSlots MergeCoreSlotsByIndex(const std::vector<GameClientDiscEntry>& previousDiscs,
                                       const std::vector<GameClientDiscEntry>& coreDiscs);
 

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -30,6 +30,7 @@ void CGameClientDiscModel::Clear()
   m_lastDiscIndex.reset();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
+  m_isEjected = false;
 }
 
 void CGameClientDiscModel::SetDiscs(const std::vector<GameClientDiscEntry>& discs)

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -78,6 +78,8 @@ public:
   bool IsSelectedNoDisc() const { return m_selectedType == DiscSelectionType::NoDisc; }
   bool HasSelectedDisc() const { return m_selectedType == DiscSelectionType::Disc; }
   std::optional<size_t> GetSelectedDiscIndex() const;
+  bool IsEjected() const { return m_isEjected; }
+  void SetEjected(bool ejected) { m_isEjected = ejected; }
 
   std::string GetSelectedDiscPath() const;
   std::string GetMainDiscPath() const;
@@ -104,6 +106,7 @@ private:
   std::optional<size_t> m_lastDiscIndex;
   DiscSelectionType m_selectedType{DiscSelectionType::NoDisc};
   std::optional<size_t> m_selectedDiscIndex;
+  bool m_isEjected{false};
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -35,10 +35,12 @@ constexpr auto XML_ROOT = "discstate";
 constexpr auto XML_SLOTS = "slots";
 constexpr auto XML_SLOT = "slot";
 constexpr auto XML_SELECTED = "selected";
+constexpr auto XML_TRAY = "tray";
 constexpr auto XML_ATTR_TYPE = "type";
 constexpr auto XML_ATTR_PATH = "path";
 constexpr auto XML_ATTR_LABEL = "label";
 constexpr auto XML_ATTR_INDEX = "index";
+constexpr auto XML_ATTR_EJECTED = "ejected";
 
 constexpr auto TYPE_DISC = "disc";
 constexpr auto TYPE_EMPTY = "empty";
@@ -136,6 +138,16 @@ void ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDis
   }
 }
 
+
+void ReadTrayFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDiscModel& model)
+{
+  const tinyxml2::XMLElement* trayElement =
+      rootElement != nullptr ? rootElement->FirstChildElement(XML_TRAY) : nullptr;
+
+  const bool isEjected = trayElement != nullptr && trayElement->BoolAttribute(XML_ATTR_EJECTED, false);
+  model.SetEjected(isEjected);
+}
+
 void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
                      tinyxml2::XMLElement* rootElement,
                      const CGameClientDiscModel& model)
@@ -181,6 +193,16 @@ void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
 
     slotsElement->InsertEndChild(slotElement);
   }
+}
+
+
+void WriteTrayToXML(CXBMCTinyXML2& xmlDoc,
+                    tinyxml2::XMLElement* rootElement,
+                    const CGameClientDiscModel& model)
+{
+  tinyxml2::XMLElement* trayElement = xmlDoc.NewElement(XML_TRAY);
+  rootElement->InsertEndChild(trayElement);
+  trayElement->SetAttribute(XML_ATTR_EJECTED, model.IsEjected());
 }
 
 void WriteSelectedToXML(CXBMCTinyXML2& xmlDoc,
@@ -249,6 +271,7 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
   }
 
   ReadSelectedFromXML(rootElement, model);
+  ReadTrayFromXML(rootElement, model);
 
   return true;
 }
@@ -272,6 +295,7 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
 
   WriteSlotsToXML(xmlDoc, rootElement, model);
   WriteSelectedToXML(xmlDoc, rootElement, model);
+  WriteTrayToXML(xmlDoc, rootElement, model);
 
   const std::string xmlPath = GetXMLPath(gamePath);
   if (!xmlDoc.SaveFile(xmlPath))

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -65,46 +65,13 @@ std::optional<size_t> GetFirstSelectable(const CGameClientDiscModel& model)
 
   return std::nullopt;
 }
-} // namespace
 
-std::string CGameClientDiscXML::GetXMLPath(const std::string& gamePath)
+std::vector<GameClientDiscEntry> ReadSlotsFromXML(const tinyxml2::XMLElement* rootElement)
 {
-  const std::string fileName = StringUtils::Format("{:08x}.xml", Crc32::Compute(gamePath));
-  return URIUtils::AddFileToFolder(GetDiscStateDirectory(), fileName);
-}
-
-bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel& model) const
-{
-  model.Clear();
-
-  if (gamePath.empty())
-    return true;
-
-  const std::string xmlPath = GetXMLPath(gamePath);
-
-  if (!CFileUtils::Exists(xmlPath))
-    return true;
-
-  CXBMCTinyXML2 xmlDoc;
-  if (!xmlDoc.LoadFile(xmlPath))
-  {
-    CLog::Log(LOGWARNING, "Failed to load disc state XML {}: {} at line {}",
-              CURL::GetRedacted(xmlPath), xmlDoc.ErrorStr(), xmlDoc.ErrorLineNum());
-    return false;
-  }
-
-  const tinyxml2::XMLElement* rootElement = xmlDoc.RootElement();
-  if (rootElement == nullptr || std::strcmp(rootElement->Name(), XML_ROOT) != 0)
-  {
-    CLog::Log(LOGWARNING, "Failed to parse disc state XML {}, missing root element '{}'",
-              CURL::GetRedacted(xmlPath), XML_ROOT);
-    model.Clear();
-    return false;
-  }
-
   std::vector<GameClientDiscEntry> discs;
 
-  const tinyxml2::XMLElement* slotsElement = rootElement->FirstChildElement(XML_SLOTS);
+  const tinyxml2::XMLElement* slotsElement =
+      rootElement != nullptr ? rootElement->FirstChildElement(XML_SLOTS) : nullptr;
   const tinyxml2::XMLElement* slotElement =
       slotsElement != nullptr ? slotsElement->FirstChildElement(XML_SLOT) : nullptr;
 
@@ -140,16 +107,13 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
     slotElement = slotElement->NextSiblingElement(XML_SLOT);
   }
 
-  model.SetDiscs(discs);
+  return discs;
+}
 
-  const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
-  if (firstSelectable.has_value())
-  {
-    model.SetMainDiscByIndex(*firstSelectable);
-    model.SetLastDiscByIndex(*firstSelectable);
-  }
-
-  const tinyxml2::XMLElement* selectedElement = rootElement->FirstChildElement(XML_SELECTED);
+void ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDiscModel& model)
+{
+  const tinyxml2::XMLElement* selectedElement =
+      rootElement != nullptr ? rootElement->FirstChildElement(XML_SELECTED) : nullptr;
   if (selectedElement != nullptr)
   {
     const char* selectedType = selectedElement->Attribute(XML_ATTR_TYPE);
@@ -170,27 +134,12 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
   {
     model.SetSelectedNoDisc();
   }
-
-  return true;
 }
 
-bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDiscModel& model) const
+void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
+                     tinyxml2::XMLElement* rootElement,
+                     const CGameClientDiscModel& model)
 {
-  if (gamePath.empty())
-    return true;
-
-  const std::string directory = GetDiscStateDirectory();
-  if (!XFILE::CDirectory::Exists(directory) && !XFILE::CDirectory::Create(directory))
-  {
-    CLog::Log(LOGWARNING, "Failed to create disc state directory {}", CURL::GetRedacted(directory));
-    return false;
-  }
-
-  CXBMCTinyXML2 xmlDoc;
-
-  tinyxml2::XMLElement* rootElement = xmlDoc.NewElement(XML_ROOT);
-  xmlDoc.InsertEndChild(rootElement);
-
   tinyxml2::XMLElement* slotsElement = xmlDoc.NewElement(XML_SLOTS);
   rootElement->InsertEndChild(slotsElement);
 
@@ -232,7 +181,12 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
 
     slotsElement->InsertEndChild(slotElement);
   }
+}
 
+void WriteSelectedToXML(CXBMCTinyXML2& xmlDoc,
+                        tinyxml2::XMLElement* rootElement,
+                        const CGameClientDiscModel& model)
+{
   tinyxml2::XMLElement* selectedElement = xmlDoc.NewElement(XML_SELECTED);
   rootElement->InsertEndChild(selectedElement);
 
@@ -247,6 +201,77 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
   {
     selectedElement->SetAttribute(XML_ATTR_TYPE, TYPE_NONE);
   }
+}
+} // namespace
+
+std::string CGameClientDiscXML::GetXMLPath(const std::string& gamePath)
+{
+  const std::string fileName = StringUtils::Format("{:08x}.xml", Crc32::Compute(gamePath));
+  return URIUtils::AddFileToFolder(GetDiscStateDirectory(), fileName);
+}
+
+bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel& model) const
+{
+  model.Clear();
+
+  if (gamePath.empty())
+    return true;
+
+  const std::string xmlPath = GetXMLPath(gamePath);
+
+  if (!CFileUtils::Exists(xmlPath))
+    return true;
+
+  CXBMCTinyXML2 xmlDoc;
+  if (!xmlDoc.LoadFile(xmlPath))
+  {
+    CLog::Log(LOGWARNING, "Failed to load disc state XML {}: {} at line {}",
+              CURL::GetRedacted(xmlPath), xmlDoc.ErrorStr(), xmlDoc.ErrorLineNum());
+    return false;
+  }
+
+  const tinyxml2::XMLElement* rootElement = xmlDoc.RootElement();
+  if (rootElement == nullptr || std::strcmp(rootElement->Name(), XML_ROOT) != 0)
+  {
+    CLog::Log(LOGWARNING, "Failed to parse disc state XML {}, missing root element '{}'",
+              CURL::GetRedacted(xmlPath), XML_ROOT);
+    model.Clear();
+    return false;
+  }
+
+  model.SetDiscs(ReadSlotsFromXML(rootElement));
+
+  const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
+  if (firstSelectable.has_value())
+  {
+    model.SetMainDiscByIndex(*firstSelectable);
+    model.SetLastDiscByIndex(*firstSelectable);
+  }
+
+  ReadSelectedFromXML(rootElement, model);
+
+  return true;
+}
+
+bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDiscModel& model) const
+{
+  if (gamePath.empty())
+    return true;
+
+  const std::string directory = GetDiscStateDirectory();
+  if (!XFILE::CDirectory::Exists(directory) && !XFILE::CDirectory::Create(directory))
+  {
+    CLog::Log(LOGWARNING, "Failed to create disc state directory {}", CURL::GetRedacted(directory));
+    return false;
+  }
+
+  CXBMCTinyXML2 xmlDoc;
+
+  tinyxml2::XMLElement* rootElement = xmlDoc.NewElement(XML_ROOT);
+  xmlDoc.InsertEndChild(rootElement);
+
+  WriteSlotsToXML(xmlDoc, rootElement, model);
+  WriteSelectedToXML(xmlDoc, rootElement, model);
 
   const std::string xmlPath = GetXMLPath(gamePath);
   if (!xmlDoc.SaveFile(xmlPath))

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -58,11 +58,66 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
   if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
   {
     *m_discModel = restoredModel;
-    RestoreDiscListBeforeLoad();
+    RestoreDiscList();
   }
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
+}
+
+void CGameClientDiscs::RestoreDiscList()
+{
+  if (m_discModel->Empty())
+    return;
+
+  if (!m_transport->SetEjectState(true))
+    return;
+
+  if (!m_transport->GetEjectState())
+    return;
+
+  unsigned int imageCount = m_transport->GetImageCount();
+
+  for (size_t i = 0; i < m_discModel->Size(); ++i)
+  {
+    if (m_discModel->IsRemovedSlotByIndex(i))
+    {
+      if (i < imageCount)
+      {
+        m_transport->RemoveImageIndex(static_cast<unsigned int>(i));
+        imageCount = m_transport->GetImageCount();
+      }
+
+      continue;
+    }
+
+    if (!m_discModel->IsRealDiscByIndex(i))
+      continue;
+
+    const std::string imagePath = m_discModel->GetPathByIndex(i);
+    if (imagePath.empty())
+      continue;
+
+    while (i >= imageCount)
+    {
+      if (!m_transport->AddImageIndex())
+        return;
+
+      imageCount = m_transport->GetImageCount();
+      if (i >= imageCount && imageCount == 0)
+        return;
+    }
+
+    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
+      return;
+  }
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
+
+  m_transport->SetEjectState(false);
 }
 
 void CGameClientDiscs::RefreshDiscState()
@@ -217,62 +272,10 @@ bool CGameClientDiscs::InsertDiscByIndex(size_t index)
   return true;
 }
 
-void CGameClientDiscs::RestoreDiscListBeforeLoad()
-{
-  if (m_discModel->Empty())
-    return;
-
-  if (!m_transport->SetEjectState(true))
-    return;
-
-  if (!m_transport->GetEjectState())
-    return;
-
-  unsigned int imageCount = m_transport->GetImageCount();
-
-  for (size_t i = 0; i < m_discModel->Size(); ++i)
-  {
-    if (m_discModel->IsRemovedSlotByIndex(i))
-    {
-      if (i < imageCount)
-      {
-        m_transport->RemoveImageIndex(static_cast<unsigned int>(i));
-        imageCount = m_transport->GetImageCount();
-      }
-
-      continue;
-    }
-
-    if (!m_discModel->IsRealDiscByIndex(i))
-      continue;
-
-    const std::string imagePath = m_discModel->GetPathByIndex(i);
-    if (imagePath.empty())
-      continue;
-
-    while (i >= imageCount)
-    {
-      if (!m_transport->AddImageIndex())
-        return;
-
-      imageCount = m_transport->GetImageCount();
-      if (i >= imageCount && imageCount == 0)
-        return;
-    }
-
-    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
-      return;
-  }
-
-  std::optional<size_t> selectedIndex;
-  std::string startupPath;
-  if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
-    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
-}
-
 void CGameClientDiscs::SaveDiscState()
 {
-  m_discXml->Save(m_gameClient.GetGamePath(), *m_discModel);
+  if (!m_gameClient.GetGamePath().empty())
+    m_discXml->Save(m_gameClient.GetGamePath(), *m_discModel);
 }
 
 void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -20,6 +20,21 @@
 using namespace KODI;
 using namespace GAME;
 
+namespace
+{
+bool HasUsableStartupDisc(const CGameClientDiscModel& model,
+                          std::optional<size_t>& selectedIndex,
+                          std::string& startupPath)
+{
+  selectedIndex = model.GetSelectedDiscIndex();
+  if (!selectedIndex.has_value() || !model.IsRealDiscByIndex(*selectedIndex))
+    return false;
+
+  startupPath = model.GetPathByIndex(*selectedIndex);
+  return !startupPath.empty();
+}
+} // namespace
+
 CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    AddonInstance_Game& addonStruct,
                                    CCriticalSection& clientAccess)
@@ -39,15 +54,14 @@ bool CGameClientDiscs::SupportsDiskControl() const
 
 void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
-  m_discXml->Load(gamePath, *m_discModel);
+  CGameClientDiscModel restoredModel;
+  if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
+    *m_discModel = restoredModel;
 
-  const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
-  if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))
-  {
-    const std::string startupPath = m_discModel->GetPathByIndex(*selectedIndex);
-    if (!startupPath.empty())
-      m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
-  }
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(restoredModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
@@ -248,6 +262,9 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 
 void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel)
 {
+  if (coreModel.Empty() && !m_discModel->Empty())
+    return;
+
   const MergedDiscSlots merged =
       MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());
 

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -58,10 +58,12 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
   if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
   {
     *m_discModel = restoredModel;
+    m_isEjected = m_discModel->IsEjected();
     RestoreDiscList();
   }
 
   m_isEjected = m_transport->GetEjectState();
+  m_discModel->SetEjected(m_isEjected);
   RefreshDiscState();
 }
 
@@ -117,7 +119,9 @@ void CGameClientDiscs::RestoreDiscList()
   if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
     m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 
-  m_transport->SetEjectState(false);
+  const bool finalEjected = m_discModel->IsEjected();
+  m_transport->SetEjectState(finalEjected);
+  m_isEjected = m_transport->GetEjectState();
 }
 
 void CGameClientDiscs::RefreshDiscState()
@@ -125,6 +129,10 @@ void CGameClientDiscs::RefreshDiscState()
   CGameClientDiscModel coreModel;
   BuildModelFromCore(coreModel);
   MergeCoreModelIntoFrontend(coreModel);
+
+  m_isEjected = m_transport->GetEjectState();
+  m_discModel->SetEjected(m_isEjected);
+
   SaveDiscState();
 }
 
@@ -134,6 +142,7 @@ bool CGameClientDiscs::SetEjected(bool ejected)
     return false;
 
   m_isEjected = m_transport->GetEjectState();
+  m_discModel->SetEjected(m_isEjected);
   RefreshDiscState();
 
   return true;
@@ -319,10 +328,13 @@ void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& co
   if (coreModel.Empty() && !m_discModel->Empty())
     return;
 
+  const bool isEjected = m_discModel->IsEjected();
+
   const MergedDiscSlots merged =
       MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());
 
   m_discModel->SetDiscs(merged.discs);
+  m_discModel->SetEjected(isEjected);
 
   if (!merged.firstSelectable.has_value())
     return;

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -56,12 +56,10 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
   CGameClientDiscModel restoredModel;
   if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
+  {
     *m_discModel = restoredModel;
-
-  std::optional<size_t> selectedIndex;
-  std::string startupPath;
-  if (HasUsableStartupDisc(restoredModel, selectedIndex, startupPath))
-    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
+    RestoreDiscListBeforeLoad();
+  }
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
@@ -217,6 +215,59 @@ bool CGameClientDiscs::InsertDiscByIndex(size_t index)
 
   RefreshDiscState();
   return true;
+}
+
+void CGameClientDiscs::RestoreDiscListBeforeLoad()
+{
+  if (m_discModel->Empty())
+    return;
+
+  if (!m_transport->SetEjectState(true))
+    return;
+
+  if (!m_transport->GetEjectState())
+    return;
+
+  unsigned int imageCount = m_transport->GetImageCount();
+
+  for (size_t i = 0; i < m_discModel->Size(); ++i)
+  {
+    if (m_discModel->IsRemovedSlotByIndex(i))
+    {
+      if (i < imageCount)
+      {
+        m_transport->RemoveImageIndex(static_cast<unsigned int>(i));
+        imageCount = m_transport->GetImageCount();
+      }
+
+      continue;
+    }
+
+    if (!m_discModel->IsRealDiscByIndex(i))
+      continue;
+
+    const std::string imagePath = m_discModel->GetPathByIndex(i);
+    if (imagePath.empty())
+      continue;
+
+    while (i >= imageCount)
+    {
+      if (!m_transport->AddImageIndex())
+        return;
+
+      imageCount = m_transport->GetImageCount();
+      if (i >= imageCount && imageCount == 0)
+        return;
+    }
+
+    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
+      return;
+  }
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 }
 
 void CGameClientDiscs::SaveDiscState()

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -25,8 +25,8 @@ CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    CCriticalSection& clientAccess)
   : CGameClientSubsystem(gameClient, addonStruct, clientAccess),
     m_transport(std::make_unique<CGameClientDiscTransport>(gameClient, addonStruct, clientAccess)),
-    m_discModel(std::make_unique<CGameClientDiscModel>()),
-    m_discXml(std::make_unique<CGameClientDiscXML>())
+    m_discXml(std::make_unique<CGameClientDiscXML>()),
+    m_discModel(std::make_unique<CGameClientDiscModel>())
 {
 }
 
@@ -37,9 +37,9 @@ bool CGameClientDiscs::SupportsDiskControl() const
   return m_gameClient.SupportsDiscControl();
 }
 
-void CGameClientDiscs::Initialize()
+void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
-  m_discXml->Load(m_gameClient.GetGamePath(), *m_discModel);
+  m_discXml->Load(gamePath, *m_discModel);
 
   const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
   if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -43,7 +43,7 @@ public:
   bool SupportsDiskControl() const;
 
   // Disc interface
-  void Initialize();
+  void Initialize(const std::string& gamePath);
   void RefreshDiscState();
   const CGameClientDiscModel& GetDiscs() const { return *m_discModel; }
   bool IsEjected() const { return m_isEjected; }

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 
 struct AddonInstance_Game;

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -45,6 +45,7 @@ public:
 
   // Disc interface
   void Initialize(const std::string& gamePath);
+  void RestoreDiscList();
   void RefreshDiscState();
   const CGameClientDiscModel& GetDiscs() const { return *m_discModel; }
   bool IsEjected() const { return m_isEjected; }
@@ -58,7 +59,6 @@ public:
 private:
   void BuildModelFromCore(CGameClientDiscModel& model) const;
   void MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel);
-  void RestoreDiscListBeforeLoad();
   void SaveDiscState();
 
   // Add-on parameters

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -58,6 +58,7 @@ public:
 private:
   void BuildModelFromCore(CGameClientDiscModel& model) const;
   void MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel);
+  void RestoreDiscListBeforeLoad();
   void SaveDiscState();
 
   // Add-on parameters

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestGameClientDiscModel.cpp
             TestGameClientDiscXML.cpp
+            TestGameClientDiscs.cpp
 )
 
 core_add_test_library(test_games_addons_disc)

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -244,3 +244,16 @@ TEST(TestGameClientDiscModel, MergePreservesTrailingRemovedSlotsWhenCoreShrinks)
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
   EXPECT_EQ(merged.discs[2].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
 }
+
+
+TEST(TestGameClientDiscModel, ClearResetsEjectedState)
+{
+  CGameClientDiscModel model;
+
+  model.SetEjected(true);
+  ASSERT_TRUE(model.IsEjected());
+
+  model.Clear();
+
+  EXPECT_FALSE(model.IsEjected());
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -24,6 +24,23 @@ void CleanupStateFile()
 {
   XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(GAME_PATH));
 }
+
+std::string ReadStateXml()
+{
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
+
+  XFILE::CFile file;
+  if (!file.Open(xmlPath))
+    return "";
+
+  std::string xml;
+  xml.resize(static_cast<size_t>(file.GetLength()));
+  if (!xml.empty())
+    file.Read(xml.data(), xml.size());
+
+  file.Close();
+  return xml;
+}
 } // namespace
 
 TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypesAndLabels)
@@ -126,4 +143,97 @@ TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreEm
   ASSERT_EQ(merged.discs.size(), 2U);
   EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+}
+
+TEST(TestGameClientDiscXML, SaveWritesEjectedTrue)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(true);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  const std::string xml = ReadStateXml();
+  EXPECT_NE(xml.find("<tray ejected=\"true\""), std::string::npos);
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, SaveWritesEjectedFalse)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(false);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  const std::string xml = ReadStateXml();
+  EXPECT_NE(xml.find("<tray ejected=\"false\""), std::string::npos);
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, LoadRestoresEjectedState)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(true);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+  EXPECT_TRUE(loadedModel.IsEjected());
+
+  CleanupStateFile();
+}
+
+
+TEST(TestGameClientDiscXML, LoadRestoresEjectedFalseState)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(false);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+  EXPECT_FALSE(loadedModel.IsEjected());
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, LoadMissingEjectedDefaultsToFalse)
+{
+  CleanupStateFile();
+
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
+
+  XFILE::CFile file;
+  ASSERT_TRUE(file.OpenForWrite(xmlPath, true));
+  static constexpr char xml[] =
+      "<discstate><slots><slot type=\"disc\" path=\"/roms/disc1.chd\"/></slots></discstate>";
+  ASSERT_EQ(file.Write(xml, sizeof(xml) - 1), sizeof(xml) - 1);
+  file.Close();
+
+  CGameClientDiscXML discXml;
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+
+  EXPECT_FALSE(loadedModel.IsEjected());
+
+  CleanupStateFile();
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "games/addons/disc/GameClientDiscMergeUtils.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscs.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+TEST(TestGameClientDiscs, PersistedModelSurvivesEmptyCoreMerge)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  CGameClientDiscModel core;
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[0].path, "/roms/disc1.chd");
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[1].path, "/roms/disc2.chd");
+}
+
+TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+
+  ASSERT_TRUE(HasUsableStartupDisc(persisted, selectedIndex, startupPath));
+  ASSERT_TRUE(selectedIndex.has_value());
+  EXPECT_EQ(*selectedIndex, 1U);
+  EXPECT_EQ(startupPath, "/roms/disc2.chd");
+}
+
+TEST(TestGameClientDiscs, EmptyPersistedAndEmptyCoreRemainEmpty)
+{
+  CGameClientDiscModel persisted;
+  CGameClientDiscModel core;
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  EXPECT_TRUE(merged.discs.empty());
+  EXPECT_FALSE(merged.firstSelectable.has_value());
+}
+
+TEST(TestGameClientDiscs, PersistedAndCoreNonEmptyStillMerge)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddRemovedSlot());
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+
+  CGameClientDiscModel core;
+  ASSERT_TRUE(core.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(core.AddDisc("/roms/disc2.chd"));
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  ASSERT_TRUE(merged.firstSelectable.has_value());
+  EXPECT_EQ(*merged.firstSelectable, 1U);
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -49,6 +49,20 @@ TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
   EXPECT_EQ(startupPath, "/roms/disc2.chd");
 }
 
+
+TEST(TestGameClientDiscs, HasUsableStartupDiscRejectsNonDiscSelection)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddRemovedSlot());
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+
+  EXPECT_FALSE(HasUsableStartupDisc(persisted, selectedIndex, startupPath));
+}
+
 TEST(TestGameClientDiscs, EmptyPersistedAndEmptyCoreRemainEmpty)
 {
   CGameClientDiscModel persisted;

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -49,7 +49,6 @@ TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
   EXPECT_EQ(startupPath, "/roms/disc2.chd");
 }
 
-
 TEST(TestGameClientDiscs, HasUsableStartupDiscRejectsNonDiscSelection)
 {
   CGameClientDiscModel persisted;


### PR DESCRIPTION
### Motivation
- Keep the tray/ejected state persisted with the disc model so the tray open/closed state is restored alongside the saved disc list. 
- Preserve existing best-effort/silent restore semantics while making the persisted state explicit and minimal in the XML. 

### Description
- Added a boolean ejected field to `CGameClientDiscModel` with `IsEjected()`/`SetEjected(bool)` accessors and reset-to-closed behavior in `Clear()`. 
- Extended XML format with a minimal `<tray ejected="..." />` element and implemented `ReadTrayFromXML()` / `WriteTrayToXML()` to load/save the model state. 
- Kept `SetDiscs()` from clobbering the explicitly persisted ejected state by reapplying the state after merges and preserved the state across `MergeCoreModelIntoFrontend()`. 
- Updated runtime flow so `RefreshDiscState()` syncs the live transport eject state into the model before saving, `SetEjected()` updates the model after a successful transport change, and `RestoreDiscList()` restores the final ejected state from the persisted model (best-effort, silent). 
- Added unit tests that validate `Clear()` resets ejected state and that XML save/load round-trips the `ejected` attribute and defaults to `false` when missing. 

### Testing
- Added unit tests under `xbmc/games/addons/disc/test/` for `CGameClientDiscModel` and `CGameClientDiscXML` covering `Clear()` reset, XML save writing of `ejected=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b03f9d8068832e8bcf6988fa418b6a)