### PR TITLE
games: remove last-disc tracking from disc model

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -266,7 +266,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
     return false;
   }
 
-  if (!InitializeGameplay(file.GetPath(), streamManager, input))
+  if (!InitializeGameplay(path, streamManager, input))
   {
     NotifyError(GAME_ERROR_UNKNOWN);
     Streams().Deinitialize();

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -604,6 +604,13 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
     bSuccess = LogError(m_ifc.game->toAddon->Deserialize(m_ifc.game, data, size), "Deserialize()");
   }
 
+  if (bSuccess)
+  {
+    // Deserialization may reset disc information, so restore it now
+    if (SupportsDiscControl())
+      Discs().RestoreDiscList();
+  }
+
   return bSuccess;
 }
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -213,7 +213,6 @@ bool CGameClient::OpenFile(const CFileItem& file,
   // Some cores "succeed" to load the file even if it doesn't exist
   if (!CFileUtils::Exists(file.GetPath()))
   {
-
     // Failed to play game
     // The required files can't be found.
     MESSAGING::HELPERS::ShowOKDialogText(
@@ -249,7 +248,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
 
   // Initialize disc control subsystem, if supported
   if (SupportsDiscControl())
-    Discs().Initialize();
+    Discs().Initialize(path);
 
   try
   {

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
@@ -13,16 +13,6 @@
 using namespace KODI;
 using namespace GAME;
 
-namespace
-{
-bool ShouldPreserveRemovedTombstone(const GameClientDiscEntry& previousDisc,
-                                    const GameClientDiscEntry& coreDisc)
-{
-  return previousDisc.slotType == GameClientDiscEntry::DiscSlotType::RemovedSlot &&
-         coreDisc.slotType == GameClientDiscEntry::DiscSlotType::EmptySlot;
-}
-} // namespace
-
 bool KODI::GAME::IsSelectableDiscSlot(const GameClientDiscEntry& discEntry)
 {
   return discEntry.slotType != GameClientDiscEntry::DiscSlotType::RemovedSlot;
@@ -39,12 +29,6 @@ MergedDiscSlots KODI::GAME::MergeCoreSlotsByIndex(
   const size_t overlapCount = std::min(previousDiscs.size(), coreDiscs.size());
   for (size_t i = 0; i < overlapCount; ++i)
   {
-    if (ShouldPreserveRemovedTombstone(previousDiscs[i], coreDiscs[i]))
-    {
-      merged.discs.push_back(previousDiscs[i]);
-      continue;
-    }
-
     merged.discs.push_back(coreDiscs[i]);
     merged.coreToMerged[i] = i;
   }

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
@@ -13,11 +13,6 @@
 using namespace KODI;
 using namespace GAME;
 
-bool KODI::GAME::IsSelectableDiscSlot(const GameClientDiscEntry& discEntry)
-{
-  return discEntry.slotType != GameClientDiscEntry::DiscSlotType::RemovedSlot;
-}
-
 MergedDiscSlots KODI::GAME::MergeCoreSlotsByIndex(
     const std::vector<GameClientDiscEntry>& previousDiscs,
     const std::vector<GameClientDiscEntry>& coreDiscs)
@@ -43,15 +38,6 @@ MergedDiscSlots KODI::GAME::MergeCoreSlotsByIndex(
   {
     merged.coreToMerged[i] = merged.discs.size();
     merged.discs.push_back(coreDiscs[i]);
-  }
-
-  for (size_t i = 0; i < merged.discs.size(); ++i)
-  {
-    if (IsSelectableDiscSlot(merged.discs[i]))
-    {
-      merged.firstSelectable = i;
-      break;
-    }
   }
 
   return merged;

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
@@ -23,10 +23,7 @@ struct MergedDiscSlots
 {
   std::vector<GameClientDiscEntry> discs;
   std::vector<std::optional<size_t>> coreToMerged;
-  std::optional<size_t> firstSelectable;
 };
-
-bool IsSelectableDiscSlot(const GameClientDiscEntry& discEntry);
 
 MergedDiscSlots MergeCoreSlotsByIndex(const std::vector<GameClientDiscEntry>& previousDiscs,
                                       const std::vector<GameClientDiscEntry>& coreDiscs);

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.h
@@ -27,6 +27,7 @@ struct MergedDiscSlots
 };
 
 bool IsSelectableDiscSlot(const GameClientDiscEntry& discEntry);
+
 MergedDiscSlots MergeCoreSlotsByIndex(const std::vector<GameClientDiscEntry>& previousDiscs,
                                       const std::vector<GameClientDiscEntry>& coreDiscs);
 

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -26,7 +26,6 @@ bool CGameClientDiscModel::Empty() const
 void CGameClientDiscModel::Clear()
 {
   m_discs.clear();
-  m_lastDiscIndex.reset();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
   m_isEjected = false;
@@ -35,7 +34,6 @@ void CGameClientDiscModel::Clear()
 void CGameClientDiscModel::SetDiscs(const std::vector<GameClientDiscEntry>& discs)
 {
   m_discs = discs;
-  m_lastDiscIndex.reset();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
 }
@@ -50,7 +48,6 @@ bool CGameClientDiscModel::AddDisc(const std::string& path, const std::string& c
 
   if (m_discs.size() == 1)
   {
-    m_lastDiscIndex = 0;
     m_selectedType = DiscSelectionType::Disc;
     m_selectedDiscIndex = 0;
   }
@@ -95,11 +92,6 @@ bool CGameClientDiscModel::MarkRemovedByIndex(size_t index)
   const bool wasSelectedDisc = (m_selectedType == DiscSelectionType::Disc &&
                                 m_selectedDiscIndex.has_value() && *m_selectedDiscIndex == index);
 
-  const bool wasLastDisc = m_lastDiscIndex.has_value() && *m_lastDiscIndex == index;
-
-  if (wasLastDisc)
-    m_lastDiscIndex = GetReplacementIndex(index);
-
   if (wasSelectedDisc)
   {
     const auto replacement = GetReplacementIndex(index);
@@ -143,24 +135,6 @@ std::optional<size_t> CGameClientDiscModel::GetDiscIndexByBasename(
   return static_cast<size_t>(it - m_discs.begin());
 }
 
-bool CGameClientDiscModel::SetLastDiscByPath(const std::string& path)
-{
-  const auto index = GetDiscIndexByPath(path);
-  if (!index.has_value())
-    return false;
-
-  return SetLastDiscByIndex(*index);
-}
-
-bool CGameClientDiscModel::SetLastDiscByIndex(size_t index)
-{
-  if (!IsSelectableSlotByIndex(index))
-    return false;
-
-  m_lastDiscIndex = index;
-  return true;
-}
-
 bool CGameClientDiscModel::SetSelectedDiscByPath(const std::string& path)
 {
   const auto index = GetDiscIndexByPath(path);
@@ -200,14 +174,6 @@ std::string CGameClientDiscModel::GetSelectedDiscPath() const
     return "";
 
   return GetPathByIndex(*m_selectedDiscIndex);
-}
-
-std::string CGameClientDiscModel::GetLastDiscPath() const
-{
-  if (!m_lastDiscIndex.has_value())
-    return "";
-
-  return GetPathByIndex(*m_lastDiscIndex);
 }
 
 bool CGameClientDiscModel::UpdateCachedLabel(const std::string& path, const std::string& label)

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -61,21 +61,6 @@ bool CGameClientDiscModel::AddDisc(const std::string& path, const std::string& c
   return true;
 }
 
-bool CGameClientDiscModel::AddEmptySlot(const std::string& cachedLabel)
-{
-  m_discs.push_back({GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", cachedLabel});
-
-  if (m_discs.size() == 1)
-  {
-    m_mainDiscIndex = 0;
-    m_lastDiscIndex = 0;
-    m_selectedType = DiscSelectionType::Disc;
-    m_selectedDiscIndex = 0;
-  }
-
-  return true;
-}
-
 bool CGameClientDiscModel::AddRemovedSlot()
 {
   m_discs.push_back({GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""});
@@ -304,9 +289,6 @@ std::string CGameClientDiscModel::GetLabelByIndex(size_t index) const
   if (!disc->cachedLabel.empty())
     return disc->cachedLabel;
 
-  if (disc->slotType == GameClientDiscEntry::DiscSlotType::EmptySlot)
-    return "";
-
   if (!disc->basename.empty())
     return disc->basename;
 
@@ -315,15 +297,6 @@ std::string CGameClientDiscModel::GetLabelByIndex(size_t index) const
     return basename;
 
   return disc->path;
-}
-
-bool CGameClientDiscModel::IsEmptySlotByIndex(size_t index) const
-{
-  const GameClientDiscEntry* disc = GetDiscByIndex(index);
-  if (disc == nullptr)
-    return false;
-
-  return disc->slotType == GameClientDiscEntry::DiscSlotType::EmptySlot;
 }
 
 bool CGameClientDiscModel::IsRemovedSlotByIndex(size_t index) const

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -30,6 +30,7 @@ void CGameClientDiscModel::Clear()
   m_lastDiscIndex.reset();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
+  m_isEjected = false;
 }
 
 void CGameClientDiscModel::SetDiscs(const std::vector<GameClientDiscEntry>& discs)

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -26,7 +26,6 @@ bool CGameClientDiscModel::Empty() const
 void CGameClientDiscModel::Clear()
 {
   m_discs.clear();
-  m_mainDiscIndex.reset();
   m_lastDiscIndex.reset();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
@@ -36,7 +35,6 @@ void CGameClientDiscModel::Clear()
 void CGameClientDiscModel::SetDiscs(const std::vector<GameClientDiscEntry>& discs)
 {
   m_discs = discs;
-  m_mainDiscIndex.reset();
   m_lastDiscIndex.reset();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
@@ -52,7 +50,6 @@ bool CGameClientDiscModel::AddDisc(const std::string& path, const std::string& c
 
   if (m_discs.size() == 1)
   {
-    m_mainDiscIndex = 0;
     m_lastDiscIndex = 0;
     m_selectedType = DiscSelectionType::Disc;
     m_selectedDiscIndex = 0;
@@ -98,14 +95,7 @@ bool CGameClientDiscModel::MarkRemovedByIndex(size_t index)
   const bool wasSelectedDisc = (m_selectedType == DiscSelectionType::Disc &&
                                 m_selectedDiscIndex.has_value() && *m_selectedDiscIndex == index);
 
-  const bool wasMainDisc = m_mainDiscIndex.has_value() && *m_mainDiscIndex == index;
   const bool wasLastDisc = m_lastDiscIndex.has_value() && *m_lastDiscIndex == index;
-
-  if (wasMainDisc)
-  {
-    const auto replacement = GetReplacementIndex(index);
-    m_mainDiscIndex = replacement;
-  }
 
   if (wasLastDisc)
     m_lastDiscIndex = GetReplacementIndex(index);
@@ -123,15 +113,6 @@ bool CGameClientDiscModel::MarkRemovedByIndex(size_t index)
       m_selectedType = DiscSelectionType::NoDisc;
       m_selectedDiscIndex.reset();
     }
-  }
-
-  if (!m_mainDiscIndex.has_value())
-    m_lastDiscIndex.reset();
-
-  if (!m_mainDiscIndex.has_value() && m_selectedType == DiscSelectionType::Disc)
-  {
-    m_selectedType = DiscSelectionType::NoDisc;
-    m_selectedDiscIndex.reset();
   }
 
   return true;
@@ -160,24 +141,6 @@ std::optional<size_t> CGameClientDiscModel::GetDiscIndexByBasename(
     return std::nullopt;
 
   return static_cast<size_t>(it - m_discs.begin());
-}
-
-bool CGameClientDiscModel::SetMainDiscByPath(const std::string& path)
-{
-  const auto index = GetDiscIndexByPath(path);
-  if (!index.has_value())
-    return false;
-
-  return SetMainDiscByIndex(*index);
-}
-
-bool CGameClientDiscModel::SetMainDiscByIndex(size_t index)
-{
-  if (!IsSelectableSlotByIndex(index))
-    return false;
-
-  m_mainDiscIndex = index;
-  return true;
 }
 
 bool CGameClientDiscModel::SetLastDiscByPath(const std::string& path)
@@ -237,14 +200,6 @@ std::string CGameClientDiscModel::GetSelectedDiscPath() const
     return "";
 
   return GetPathByIndex(*m_selectedDiscIndex);
-}
-
-std::string CGameClientDiscModel::GetMainDiscPath() const
-{
-  if (!m_mainDiscIndex.has_value())
-    return "";
-
-  return GetPathByIndex(*m_mainDiscIndex);
 }
 
 std::string CGameClientDiscModel::GetLastDiscPath() const

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -78,6 +78,8 @@ public:
   bool IsSelectedNoDisc() const { return m_selectedType == DiscSelectionType::NoDisc; }
   bool HasSelectedDisc() const { return m_selectedType == DiscSelectionType::Disc; }
   std::optional<size_t> GetSelectedDiscIndex() const;
+  bool IsEjected() const { return m_isEjected; }
+  void SetEjected(bool ejected) { m_isEjected = ejected; }
 
   std::string GetSelectedDiscPath() const;
   std::string GetMainDiscPath() const;
@@ -104,6 +106,7 @@ private:
   std::optional<size_t> m_lastDiscIndex;
   DiscSelectionType m_selectedType{DiscSelectionType::NoDisc};
   std::optional<size_t> m_selectedDiscIndex;
+  bool m_isEjected{false};
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -23,7 +23,6 @@ struct GameClientDiscEntry
   enum class DiscSlotType
   {
     Disc,
-    EmptySlot,
     RemovedSlot,
   };
 
@@ -57,7 +56,6 @@ public:
   void SetDiscs(const std::vector<GameClientDiscEntry>& discs);
 
   bool AddDisc(const std::string& path, const std::string& cachedLabel = "");
-  bool AddEmptySlot(const std::string& cachedLabel = "");
   bool AddRemovedSlot();
   bool RemoveDiscByPath(const std::string& path);
   bool RemoveDiscByIndex(size_t index);
@@ -90,7 +88,6 @@ public:
   std::string GetPathByIndex(size_t index) const;
   std::string GetLabelByIndex(size_t index) const;
 
-  bool IsEmptySlotByIndex(size_t index) const;
   bool IsRemovedSlotByIndex(size_t index) const;
   bool IsSelectableSlotByIndex(size_t index) const;
   bool IsRealDiscByIndex(size_t index) const;

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -44,11 +44,10 @@ public:
   };
 
   // Model invariants:
-  // - m_mainDiscIndex, m_lastDiscIndex and m_selectedDiscIndex (when selection type is Disc)
-  //   always refer to an existing entry in m_discs.
+  // - m_lastDiscIndex and m_selectedDiscIndex (when selection type is Disc) always refer to
+  //   an existing entry in m_discs.
   // - For removal replacement (selected/last): prefer same index if still valid, otherwise
   //   previous valid index, otherwise no replacement.
-  // - Main disc replacement is separate: if removed, use first remaining disc or clear.
   size_t Size() const;
   bool Empty() const;
 
@@ -66,8 +65,6 @@ public:
   std::optional<size_t> GetDiscIndexByPath(const std::string& path) const;
   std::optional<size_t> GetDiscIndexByBasename(const std::string& basename) const;
 
-  bool SetMainDiscByPath(const std::string& path);
-  bool SetMainDiscByIndex(size_t index);
   bool SetLastDiscByPath(const std::string& path);
   bool SetLastDiscByIndex(size_t index);
   bool SetSelectedDiscByPath(const std::string& path);
@@ -80,7 +77,6 @@ public:
   void SetEjected(bool ejected) { m_isEjected = ejected; }
 
   std::string GetSelectedDiscPath() const;
-  std::string GetMainDiscPath() const;
   std::string GetLastDiscPath() const;
 
   bool UpdateCachedLabel(const std::string& path, const std::string& label);
@@ -99,7 +95,6 @@ private:
   std::optional<size_t> GetReplacementIndex(size_t removedIndex) const;
 
   std::vector<GameClientDiscEntry> m_discs;
-  std::optional<size_t> m_mainDiscIndex;
   std::optional<size_t> m_lastDiscIndex;
   DiscSelectionType m_selectedType{DiscSelectionType::NoDisc};
   std::optional<size_t> m_selectedDiscIndex;

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -44,10 +44,10 @@ public:
   };
 
   // Model invariants:
-  // - m_lastDiscIndex and m_selectedDiscIndex (when selection type is Disc) always refer to
-  //   an existing entry in m_discs.
-  // - For removal replacement (selected/last): prefer same index if still valid, otherwise
-  //   previous valid index, otherwise no replacement.
+  // - m_selectedDiscIndex (when selection type is Disc) always refers to an existing entry
+  //   in m_discs.
+  // - For removal replacement (selected): prefer same index if still valid, otherwise previous
+  //   valid index, otherwise no replacement.
   size_t Size() const;
   bool Empty() const;
 
@@ -65,8 +65,6 @@ public:
   std::optional<size_t> GetDiscIndexByPath(const std::string& path) const;
   std::optional<size_t> GetDiscIndexByBasename(const std::string& basename) const;
 
-  bool SetLastDiscByPath(const std::string& path);
-  bool SetLastDiscByIndex(size_t index);
   bool SetSelectedDiscByPath(const std::string& path);
   bool SetSelectedDiscByIndex(size_t index);
   void SetSelectedNoDisc();
@@ -77,8 +75,6 @@ public:
   void SetEjected(bool ejected) { m_isEjected = ejected; }
 
   std::string GetSelectedDiscPath() const;
-  std::string GetLastDiscPath() const;
-
   bool UpdateCachedLabel(const std::string& path, const std::string& label);
 
   std::string GetPathByIndex(size_t index) const;
@@ -95,7 +91,6 @@ private:
   std::optional<size_t> GetReplacementIndex(size_t removedIndex) const;
 
   std::vector<GameClientDiscEntry> m_discs;
-  std::optional<size_t> m_lastDiscIndex;
   DiscSelectionType m_selectedType{DiscSelectionType::NoDisc};
   std::optional<size_t> m_selectedDiscIndex;
   bool m_isEjected{false};

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -43,7 +43,7 @@ constexpr auto XML_ATTR_INDEX = "index";
 constexpr auto XML_ATTR_EJECTED = "ejected";
 
 constexpr auto TYPE_DISC = "disc";
-constexpr auto TYPE_EMPTY = "empty";
+constexpr auto TYPE_EMPTY = "empty"; // legacy: load-only, maps to removed tombstone
 constexpr auto TYPE_REMOVED = "removed";
 constexpr auto TYPE_NONE = "none";
 
@@ -90,7 +90,8 @@ std::vector<GameClientDiscEntry> ReadSlotsFromXML(const tinyxml2::XMLElement* ro
     }
     else if (type != nullptr && std::strcmp(type, TYPE_EMPTY) == 0)
     {
-      discs.push_back({GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", label});
+      // Backward compatibility: old empty slots are now removed tombstones.
+      discs.push_back({GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""});
     }
     else
     {
@@ -102,7 +103,7 @@ std::vector<GameClientDiscEntry> ReadSlotsFromXML(const tinyxml2::XMLElement* ro
       }
       else
       {
-        discs.push_back({GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", label});
+        discs.push_back({GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""});
       }
     }
 
@@ -170,16 +171,9 @@ void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
         }
         else
         {
-          slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_EMPTY);
+          slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_REMOVED);
         }
 
-        if (!disc.cachedLabel.empty())
-          slotElement->SetAttribute(XML_ATTR_LABEL, disc.cachedLabel.c_str());
-        break;
-      }
-      case GameClientDiscEntry::DiscSlotType::EmptySlot:
-      {
-        slotElement->SetAttribute(XML_ATTR_TYPE, TYPE_EMPTY);
         if (!disc.cachedLabel.empty())
           slotElement->SetAttribute(XML_ATTR_LABEL, disc.cachedLabel.c_str());
         break;

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -57,17 +57,6 @@ bool IsPersistableDiscPath(const std::string& path)
   return !path.empty() && !URIUtils::IsProtocol(path, "disc");
 }
 
-std::optional<size_t> GetFirstSelectable(const CGameClientDiscModel& model)
-{
-  for (size_t i = 0; i < model.Size(); ++i)
-  {
-    if (model.IsSelectableSlotByIndex(i))
-      return i;
-  }
-
-  return std::nullopt;
-}
-
 std::vector<GameClientDiscEntry> ReadSlotsFromXML(const tinyxml2::XMLElement* rootElement)
 {
   std::vector<GameClientDiscEntry> discs;
@@ -255,10 +244,6 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
   }
 
   model.SetDiscs(ReadSlotsFromXML(rootElement));
-
-  const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
-  if (firstSelectable.has_value())
-    model.SetLastDiscByIndex(*firstSelectable);
 
   ReadSelectedFromXML(rootElement, model);
   ReadTrayFromXML(rootElement, model);

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -35,10 +35,12 @@ constexpr auto XML_ROOT = "discstate";
 constexpr auto XML_SLOTS = "slots";
 constexpr auto XML_SLOT = "slot";
 constexpr auto XML_SELECTED = "selected";
+constexpr auto XML_TRAY = "tray";
 constexpr auto XML_ATTR_TYPE = "type";
 constexpr auto XML_ATTR_PATH = "path";
 constexpr auto XML_ATTR_LABEL = "label";
 constexpr auto XML_ATTR_INDEX = "index";
+constexpr auto XML_ATTR_EJECTED = "ejected";
 
 constexpr auto TYPE_DISC = "disc";
 constexpr auto TYPE_EMPTY = "empty";
@@ -136,6 +138,16 @@ void ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDis
   }
 }
 
+void ReadTrayFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDiscModel& model)
+{
+  const tinyxml2::XMLElement* trayElement =
+      rootElement != nullptr ? rootElement->FirstChildElement(XML_TRAY) : nullptr;
+
+  const bool isEjected =
+      trayElement != nullptr && trayElement->BoolAttribute(XML_ATTR_EJECTED, false);
+  model.SetEjected(isEjected);
+}
+
 void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
                      tinyxml2::XMLElement* rootElement,
                      const CGameClientDiscModel& model)
@@ -181,6 +193,15 @@ void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
 
     slotsElement->InsertEndChild(slotElement);
   }
+}
+
+void WriteTrayToXML(CXBMCTinyXML2& xmlDoc,
+                    tinyxml2::XMLElement* rootElement,
+                    const CGameClientDiscModel& model)
+{
+  tinyxml2::XMLElement* trayElement = xmlDoc.NewElement(XML_TRAY);
+  rootElement->InsertEndChild(trayElement);
+  trayElement->SetAttribute(XML_ATTR_EJECTED, model.IsEjected());
 }
 
 void WriteSelectedToXML(CXBMCTinyXML2& xmlDoc,
@@ -249,6 +270,7 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
   }
 
   ReadSelectedFromXML(rootElement, model);
+  ReadTrayFromXML(rootElement, model);
 
   return true;
 }
@@ -272,6 +294,7 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
 
   WriteSlotsToXML(xmlDoc, rootElement, model);
   WriteSelectedToXML(xmlDoc, rootElement, model);
+  WriteTrayToXML(xmlDoc, rootElement, model);
 
   const std::string xmlPath = GetXMLPath(gamePath);
   if (!xmlDoc.SaveFile(xmlPath))

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -258,10 +258,7 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
 
   const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
   if (firstSelectable.has_value())
-  {
-    model.SetMainDiscByIndex(*firstSelectable);
     model.SetLastDiscByIndex(*firstSelectable);
-  }
 
   ReadSelectedFromXML(rootElement, model);
   ReadTrayFromXML(rootElement, model);

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -65,46 +65,13 @@ std::optional<size_t> GetFirstSelectable(const CGameClientDiscModel& model)
 
   return std::nullopt;
 }
-} // namespace
 
-std::string CGameClientDiscXML::GetXMLPath(const std::string& gamePath)
+std::vector<GameClientDiscEntry> ReadSlotsFromXML(const tinyxml2::XMLElement* rootElement)
 {
-  const std::string fileName = StringUtils::Format("{:08x}.xml", Crc32::Compute(gamePath));
-  return URIUtils::AddFileToFolder(GetDiscStateDirectory(), fileName);
-}
-
-bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel& model) const
-{
-  model.Clear();
-
-  if (gamePath.empty())
-    return true;
-
-  const std::string xmlPath = GetXMLPath(gamePath);
-
-  if (!CFileUtils::Exists(xmlPath))
-    return true;
-
-  CXBMCTinyXML2 xmlDoc;
-  if (!xmlDoc.LoadFile(xmlPath))
-  {
-    CLog::Log(LOGWARNING, "Failed to load disc state XML {}: {} at line {}",
-              CURL::GetRedacted(xmlPath), xmlDoc.ErrorStr(), xmlDoc.ErrorLineNum());
-    return false;
-  }
-
-  const tinyxml2::XMLElement* rootElement = xmlDoc.RootElement();
-  if (rootElement == nullptr || std::strcmp(rootElement->Name(), XML_ROOT) != 0)
-  {
-    CLog::Log(LOGWARNING, "Failed to parse disc state XML {}, missing root element '{}'",
-              CURL::GetRedacted(xmlPath), XML_ROOT);
-    model.Clear();
-    return false;
-  }
-
   std::vector<GameClientDiscEntry> discs;
 
-  const tinyxml2::XMLElement* slotsElement = rootElement->FirstChildElement(XML_SLOTS);
+  const tinyxml2::XMLElement* slotsElement =
+      rootElement != nullptr ? rootElement->FirstChildElement(XML_SLOTS) : nullptr;
   const tinyxml2::XMLElement* slotElement =
       slotsElement != nullptr ? slotsElement->FirstChildElement(XML_SLOT) : nullptr;
 
@@ -140,16 +107,13 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
     slotElement = slotElement->NextSiblingElement(XML_SLOT);
   }
 
-  model.SetDiscs(discs);
+  return discs;
+}
 
-  const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
-  if (firstSelectable.has_value())
-  {
-    model.SetMainDiscByIndex(*firstSelectable);
-    model.SetLastDiscByIndex(*firstSelectable);
-  }
-
-  const tinyxml2::XMLElement* selectedElement = rootElement->FirstChildElement(XML_SELECTED);
+void ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDiscModel& model)
+{
+  const tinyxml2::XMLElement* selectedElement =
+      rootElement != nullptr ? rootElement->FirstChildElement(XML_SELECTED) : nullptr;
   if (selectedElement != nullptr)
   {
     const char* selectedType = selectedElement->Attribute(XML_ATTR_TYPE);
@@ -170,27 +134,12 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
   {
     model.SetSelectedNoDisc();
   }
-
-  return true;
 }
 
-bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDiscModel& model) const
+void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
+                     tinyxml2::XMLElement* rootElement,
+                     const CGameClientDiscModel& model)
 {
-  if (gamePath.empty())
-    return true;
-
-  const std::string directory = GetDiscStateDirectory();
-  if (!XFILE::CDirectory::Exists(directory) && !XFILE::CDirectory::Create(directory))
-  {
-    CLog::Log(LOGWARNING, "Failed to create disc state directory {}", CURL::GetRedacted(directory));
-    return false;
-  }
-
-  CXBMCTinyXML2 xmlDoc;
-
-  tinyxml2::XMLElement* rootElement = xmlDoc.NewElement(XML_ROOT);
-  xmlDoc.InsertEndChild(rootElement);
-
   tinyxml2::XMLElement* slotsElement = xmlDoc.NewElement(XML_SLOTS);
   rootElement->InsertEndChild(slotsElement);
 
@@ -232,7 +181,12 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
 
     slotsElement->InsertEndChild(slotElement);
   }
+}
 
+void WriteSelectedToXML(CXBMCTinyXML2& xmlDoc,
+                        tinyxml2::XMLElement* rootElement,
+                        const CGameClientDiscModel& model)
+{
   tinyxml2::XMLElement* selectedElement = xmlDoc.NewElement(XML_SELECTED);
   rootElement->InsertEndChild(selectedElement);
 
@@ -247,6 +201,77 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
   {
     selectedElement->SetAttribute(XML_ATTR_TYPE, TYPE_NONE);
   }
+}
+} // namespace
+
+std::string CGameClientDiscXML::GetXMLPath(const std::string& gamePath)
+{
+  const std::string fileName = StringUtils::Format("{:08x}.xml", Crc32::Compute(gamePath));
+  return URIUtils::AddFileToFolder(GetDiscStateDirectory(), fileName);
+}
+
+bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel& model) const
+{
+  model.Clear();
+
+  if (gamePath.empty())
+    return true;
+
+  const std::string xmlPath = GetXMLPath(gamePath);
+
+  if (!CFileUtils::Exists(xmlPath))
+    return true;
+
+  CXBMCTinyXML2 xmlDoc;
+  if (!xmlDoc.LoadFile(xmlPath))
+  {
+    CLog::Log(LOGWARNING, "Failed to load disc state XML {}: {} at line {}",
+              CURL::GetRedacted(xmlPath), xmlDoc.ErrorStr(), xmlDoc.ErrorLineNum());
+    return false;
+  }
+
+  const tinyxml2::XMLElement* rootElement = xmlDoc.RootElement();
+  if (rootElement == nullptr || std::strcmp(rootElement->Name(), XML_ROOT) != 0)
+  {
+    CLog::Log(LOGWARNING, "Failed to parse disc state XML {}, missing root element '{}'",
+              CURL::GetRedacted(xmlPath), XML_ROOT);
+    model.Clear();
+    return false;
+  }
+
+  model.SetDiscs(ReadSlotsFromXML(rootElement));
+
+  const std::optional<size_t> firstSelectable = GetFirstSelectable(model);
+  if (firstSelectable.has_value())
+  {
+    model.SetMainDiscByIndex(*firstSelectable);
+    model.SetLastDiscByIndex(*firstSelectable);
+  }
+
+  ReadSelectedFromXML(rootElement, model);
+
+  return true;
+}
+
+bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDiscModel& model) const
+{
+  if (gamePath.empty())
+    return true;
+
+  const std::string directory = GetDiscStateDirectory();
+  if (!XFILE::CDirectory::Exists(directory) && !XFILE::CDirectory::Create(directory))
+  {
+    CLog::Log(LOGWARNING, "Failed to create disc state directory {}", CURL::GetRedacted(directory));
+    return false;
+  }
+
+  CXBMCTinyXML2 xmlDoc;
+
+  tinyxml2::XMLElement* rootElement = xmlDoc.NewElement(XML_ROOT);
+  xmlDoc.InsertEndChild(rootElement);
+
+  WriteSlotsToXML(xmlDoc, rootElement, model);
+  WriteSelectedToXML(xmlDoc, rootElement, model);
 
   const std::string xmlPath = GetXMLPath(gamePath);
   if (!xmlDoc.SaveFile(xmlPath))

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -308,8 +308,6 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
   if (model.Empty())
     return;
 
-  model.SetMainDiscByIndex(0);
-
   const unsigned int imageIndex = m_transport->GetImageIndex();
 
   if (imageIndex < imageCount)
@@ -339,8 +337,6 @@ void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& co
 
   if (!merged.firstSelectable.has_value())
     return;
-
-  m_discModel->SetMainDiscByIndex(*merged.firstSelectable);
 
   const std::optional<size_t> selectedCoreIndex = coreModel.GetSelectedDiscIndex();
   if (selectedCoreIndex.has_value() && *selectedCoreIndex < merged.coreToMerged.size())

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -58,11 +58,66 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
   if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
   {
     *m_discModel = restoredModel;
-    RestoreDiscListBeforeLoad();
+    RestoreDiscList();
   }
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
+}
+
+void CGameClientDiscs::RestoreDiscList()
+{
+  if (m_discModel->Empty())
+    return;
+
+  if (!m_transport->SetEjectState(true))
+    return;
+
+  if (!m_transport->GetEjectState())
+    return;
+
+  unsigned int imageCount = m_transport->GetImageCount();
+
+  for (size_t i = 0; i < m_discModel->Size(); ++i)
+  {
+    if (m_discModel->IsRemovedSlotByIndex(i))
+    {
+      if (i < imageCount)
+      {
+        m_transport->RemoveImageIndex(static_cast<unsigned int>(i));
+        imageCount = m_transport->GetImageCount();
+      }
+
+      continue;
+    }
+
+    if (!m_discModel->IsRealDiscByIndex(i))
+      continue;
+
+    const std::string imagePath = m_discModel->GetPathByIndex(i);
+    if (imagePath.empty())
+      continue;
+
+    while (i >= imageCount)
+    {
+      if (!m_transport->AddImageIndex())
+        return;
+
+      imageCount = m_transport->GetImageCount();
+      if (i >= imageCount && imageCount == 0)
+        return;
+    }
+
+    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
+      return;
+  }
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
+
+  m_transport->SetEjectState(false);
 }
 
 void CGameClientDiscs::RefreshDiscState()
@@ -217,62 +272,10 @@ bool CGameClientDiscs::InsertDiscByIndex(size_t index)
   return true;
 }
 
-void CGameClientDiscs::RestoreDiscListBeforeLoad()
-{
-  if (m_discModel->Empty())
-    return;
-
-  if (!m_transport->SetEjectState(true))
-    return;
-
-  if (!m_transport->GetEjectState())
-    return;
-
-  unsigned int imageCount = m_transport->GetImageCount();
-
-  for (size_t i = 0; i < m_discModel->Size(); ++i)
-  {
-    if (m_discModel->IsRemovedSlotByIndex(i))
-    {
-      if (i < imageCount)
-      {
-        m_transport->RemoveImageIndex(static_cast<unsigned int>(i));
-        imageCount = m_transport->GetImageCount();
-      }
-
-      continue;
-    }
-
-    if (!m_discModel->IsRealDiscByIndex(i))
-      continue;
-
-    const std::string imagePath = m_discModel->GetPathByIndex(i);
-    if (imagePath.empty())
-      continue;
-
-    while (i >= imageCount)
-    {
-      if (!m_transport->AddImageIndex())
-        return;
-
-      imageCount = m_transport->GetImageCount();
-      if (i >= imageCount && imageCount == 0)
-        return;
-    }
-
-    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
-      return;
-  }
-
-  std::optional<size_t> selectedIndex;
-  std::string startupPath;
-  if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
-    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
-}
-
 void CGameClientDiscs::SaveDiscState()
 {
-  m_discXml->Save(m_gameClient.GetGamePath(), *m_discModel);
+  if (!m_gameClient.GetGamePath().empty())
+    m_discXml->Save(m_gameClient.GetGamePath(), *m_discModel);
 }
 
 void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -20,6 +20,21 @@
 using namespace KODI;
 using namespace GAME;
 
+namespace
+{
+bool HasUsableStartupDisc(const CGameClientDiscModel& model,
+                          std::optional<size_t>& selectedIndex,
+                          std::string& startupPath)
+{
+  selectedIndex = model.GetSelectedDiscIndex();
+  if (!selectedIndex.has_value() || !model.IsRealDiscByIndex(*selectedIndex))
+    return false;
+
+  startupPath = model.GetPathByIndex(*selectedIndex);
+  return !startupPath.empty();
+}
+} // namespace
+
 CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    AddonInstance_Game& addonStruct,
                                    CCriticalSection& clientAccess)
@@ -39,15 +54,14 @@ bool CGameClientDiscs::SupportsDiskControl() const
 
 void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
-  m_discXml->Load(gamePath, *m_discModel);
+  CGameClientDiscModel restoredModel;
+  if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
+    *m_discModel = restoredModel;
 
-  const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
-  if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))
-  {
-    const std::string startupPath = m_discModel->GetPathByIndex(*selectedIndex);
-    if (!startupPath.empty())
-      m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
-  }
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(restoredModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
@@ -248,6 +262,9 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 
 void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel)
 {
+  if (coreModel.Empty() && !m_discModel->Empty())
+    return;
+
   const MergedDiscSlots merged =
       MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());
 

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -302,7 +302,7 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
     const std::string imageLabel = m_transport->GetImageLabel(i);
 
     if (imagePath.empty())
-      model.AddEmptySlot(imageLabel);
+      model.AddRemovedSlot();
     else
       model.AddDisc(imagePath, imageLabel);
   }

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -58,10 +58,12 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
   if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
   {
     *m_discModel = restoredModel;
+    m_isEjected = m_discModel->IsEjected();
     RestoreDiscList();
   }
 
   m_isEjected = m_transport->GetEjectState();
+  m_discModel->SetEjected(m_isEjected);
   RefreshDiscState();
 }
 
@@ -117,7 +119,9 @@ void CGameClientDiscs::RestoreDiscList()
   if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
     m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 
-  m_transport->SetEjectState(false);
+  const bool finalEjected = m_discModel->IsEjected();
+  m_transport->SetEjectState(finalEjected);
+  m_isEjected = m_transport->GetEjectState();
 }
 
 void CGameClientDiscs::RefreshDiscState()
@@ -125,6 +129,10 @@ void CGameClientDiscs::RefreshDiscState()
   CGameClientDiscModel coreModel;
   BuildModelFromCore(coreModel);
   MergeCoreModelIntoFrontend(coreModel);
+
+  m_isEjected = m_transport->GetEjectState();
+  m_discModel->SetEjected(m_isEjected);
+
   SaveDiscState();
 }
 
@@ -134,6 +142,7 @@ bool CGameClientDiscs::SetEjected(bool ejected)
     return false;
 
   m_isEjected = m_transport->GetEjectState();
+  m_discModel->SetEjected(m_isEjected);
   RefreshDiscState();
 
   return true;
@@ -319,10 +328,13 @@ void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& co
   if (coreModel.Empty() && !m_discModel->Empty())
     return;
 
+  const bool isEjected = m_discModel->IsEjected();
+
   const MergedDiscSlots merged =
       MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());
 
   m_discModel->SetDiscs(merged.discs);
+  m_discModel->SetEjected(isEjected);
 
   if (!merged.firstSelectable.has_value())
     return;

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -290,7 +290,7 @@ void CGameClientDiscs::SaveDiscState()
 void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 {
   model.Clear();
-  
+
   // Load ejected state
   model.SetEjected(m_transport->GetEjectState());
 

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -312,12 +312,10 @@ void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 
   if (imageIndex < imageCount)
   {
-    model.SetLastDiscByIndex(imageIndex);
     model.SetSelectedDiscByIndex(imageIndex);
   }
   else
   {
-    model.SetLastDiscByIndex(0);
     model.SetSelectedNoDisc();
   }
 }
@@ -335,9 +333,6 @@ void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& co
   m_discModel->SetDiscs(merged.discs);
   m_discModel->SetEjected(isEjected);
 
-  if (!merged.firstSelectable.has_value())
-    return;
-
   const std::optional<size_t> selectedCoreIndex = coreModel.GetSelectedDiscIndex();
   if (selectedCoreIndex.has_value() && *selectedCoreIndex < merged.coreToMerged.size())
   {
@@ -346,12 +341,10 @@ void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& co
     if (selectedMergedIndex.has_value() &&
         m_discModel->IsSelectableSlotByIndex(*selectedMergedIndex))
     {
-      m_discModel->SetLastDiscByIndex(*selectedMergedIndex);
       m_discModel->SetSelectedDiscByIndex(*selectedMergedIndex);
       return;
     }
   }
 
-  m_discModel->SetLastDiscByIndex(*merged.firstSelectable);
   m_discModel->SetSelectedNoDisc();
 }

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -56,12 +56,10 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
   CGameClientDiscModel restoredModel;
   if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
+  {
     *m_discModel = restoredModel;
-
-  std::optional<size_t> selectedIndex;
-  std::string startupPath;
-  if (HasUsableStartupDisc(restoredModel, selectedIndex, startupPath))
-    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
+    RestoreDiscListBeforeLoad();
+  }
 
   m_isEjected = m_transport->GetEjectState();
   RefreshDiscState();
@@ -217,6 +215,59 @@ bool CGameClientDiscs::InsertDiscByIndex(size_t index)
 
   RefreshDiscState();
   return true;
+}
+
+void CGameClientDiscs::RestoreDiscListBeforeLoad()
+{
+  if (m_discModel->Empty())
+    return;
+
+  if (!m_transport->SetEjectState(true))
+    return;
+
+  if (!m_transport->GetEjectState())
+    return;
+
+  unsigned int imageCount = m_transport->GetImageCount();
+
+  for (size_t i = 0; i < m_discModel->Size(); ++i)
+  {
+    if (m_discModel->IsRemovedSlotByIndex(i))
+    {
+      if (i < imageCount)
+      {
+        m_transport->RemoveImageIndex(static_cast<unsigned int>(i));
+        imageCount = m_transport->GetImageCount();
+      }
+
+      continue;
+    }
+
+    if (!m_discModel->IsRealDiscByIndex(i))
+      continue;
+
+    const std::string imagePath = m_discModel->GetPathByIndex(i);
+    if (imagePath.empty())
+      continue;
+
+    while (i >= imageCount)
+    {
+      if (!m_transport->AddImageIndex())
+        return;
+
+      imageCount = m_transport->GetImageCount();
+      if (i >= imageCount && imageCount == 0)
+        return;
+    }
+
+    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
+      return;
+  }
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+  if (HasUsableStartupDisc(*m_discModel, selectedIndex, startupPath))
+    m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
 }
 
 void CGameClientDiscs::SaveDiscState()

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -62,8 +62,6 @@ void CGameClientDiscs::Initialize(const std::string& gamePath)
     RestoreDiscList();
   }
 
-  m_isEjected = m_transport->GetEjectState();
-  m_discModel->SetEjected(m_isEjected);
   RefreshDiscState();
 }
 

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -130,7 +130,7 @@ void CGameClientDiscs::RefreshDiscState()
   BuildModelFromCore(coreModel);
   MergeCoreModelIntoFrontend(coreModel);
 
-  m_isEjected = m_transport->GetEjectState();
+  m_isEjected = coreModel.IsEjected();
   m_discModel->SetEjected(m_isEjected);
 
   SaveDiscState();
@@ -290,6 +290,9 @@ void CGameClientDiscs::SaveDiscState()
 void CGameClientDiscs::BuildModelFromCore(CGameClientDiscModel& model) const
 {
   model.Clear();
+  
+  // Load ejected state
+  model.SetEjected(m_transport->GetEjectState());
 
   const unsigned int imageCount = m_transport->GetImageCount();
 
@@ -328,7 +331,7 @@ void CGameClientDiscs::MergeCoreModelIntoFrontend(const CGameClientDiscModel& co
   if (coreModel.Empty() && !m_discModel->Empty())
     return;
 
-  const bool isEjected = m_discModel->IsEjected();
+  const bool isEjected = coreModel.IsEjected();
 
   const MergedDiscSlots merged =
       MergeCoreSlotsByIndex(m_discModel->GetDiscs(), coreModel.GetDiscs());

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -25,8 +25,8 @@ CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    CCriticalSection& clientAccess)
   : CGameClientSubsystem(gameClient, addonStruct, clientAccess),
     m_transport(std::make_unique<CGameClientDiscTransport>(gameClient, addonStruct, clientAccess)),
-    m_discModel(std::make_unique<CGameClientDiscModel>()),
-    m_discXml(std::make_unique<CGameClientDiscXML>())
+    m_discXml(std::make_unique<CGameClientDiscXML>()),
+    m_discModel(std::make_unique<CGameClientDiscModel>())
 {
 }
 
@@ -37,9 +37,9 @@ bool CGameClientDiscs::SupportsDiskControl() const
   return m_gameClient.SupportsDiscControl();
 }
 
-void CGameClientDiscs::Initialize()
+void CGameClientDiscs::Initialize(const std::string& gamePath)
 {
-  m_discXml->Load(m_gameClient.GetGamePath(), *m_discModel);
+  m_discXml->Load(gamePath, *m_discModel);
 
   const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
   if (selectedIndex.has_value() && m_discModel->IsRealDiscByIndex(*selectedIndex))

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -43,7 +43,7 @@ public:
   bool SupportsDiskControl() const;
 
   // Disc interface
-  void Initialize();
+  void Initialize(const std::string& gamePath);
   void RefreshDiscState();
   const CGameClientDiscModel& GetDiscs() const { return *m_discModel; }
   bool IsEjected() const { return m_isEjected; }

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 
 struct AddonInstance_Game;

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -45,6 +45,7 @@ public:
 
   // Disc interface
   void Initialize(const std::string& gamePath);
+  void RestoreDiscList();
   void RefreshDiscState();
   const CGameClientDiscModel& GetDiscs() const { return *m_discModel; }
   bool IsEjected() const { return m_isEjected; }
@@ -58,7 +59,6 @@ public:
 private:
   void BuildModelFromCore(CGameClientDiscModel& model) const;
   void MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel);
-  void RestoreDiscListBeforeLoad();
   void SaveDiscState();
 
   // Add-on parameters

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -58,6 +58,7 @@ public:
 private:
   void BuildModelFromCore(CGameClientDiscModel& model) const;
   void MergeCoreModelIntoFrontend(const CGameClientDiscModel& coreModel);
+  void RestoreDiscListBeforeLoad();
   void SaveDiscState();
 
   // Add-on parameters

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestGameClientDiscModel.cpp
             TestGameClientDiscXML.cpp
+            TestGameClientDiscs.cpp
 )
 
 core_add_test_library(test_games_addons_disc)

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -89,14 +89,13 @@ TEST(TestGameClientDiscModel, ReplacementSkipsRemovedSlots)
   EXPECT_EQ(model.GetLastDiscPath(), "/roms/disc1.chd");
 }
 
-TEST(TestGameClientDiscModel, SelectionMainAndLastDoNotPointToRemoved)
+TEST(TestGameClientDiscModel, SelectionAndLastDoNotPointToRemoved)
 {
   // Verify tracked indices are redirected away from removed slots.
   CGameClientDiscModel model;
 
   ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
   ASSERT_TRUE(model.AddDisc("/roms/disc2.chd"));
-  ASSERT_TRUE(model.SetMainDiscByIndex(1));
   ASSERT_TRUE(model.SetLastDiscByIndex(1));
   ASSERT_TRUE(model.SetSelectedDiscByIndex(1));
 
@@ -104,8 +103,23 @@ TEST(TestGameClientDiscModel, SelectionMainAndLastDoNotPointToRemoved)
 
   ASSERT_TRUE(model.GetSelectedDiscIndex().has_value());
   EXPECT_EQ(*model.GetSelectedDiscIndex(), 0U);
-  EXPECT_EQ(model.GetMainDiscPath(), "/roms/disc1.chd");
   EXPECT_EQ(model.GetLastDiscPath(), "/roms/disc1.chd");
+}
+
+
+TEST(TestGameClientDiscModel, RemovingOnlySelectedDiscClearsSelectionAndLast)
+{
+  CGameClientDiscModel model;
+
+  ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(model.SetLastDiscByIndex(0));
+  ASSERT_TRUE(model.SetSelectedDiscByIndex(0));
+
+  ASSERT_TRUE(model.MarkRemovedByIndex(0));
+
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_FALSE(model.GetSelectedDiscIndex().has_value());
+  EXPECT_EQ(model.GetLastDiscPath(), "");
 }
 
 TEST(TestGameClientDiscModel, MixedSlotModelBehavior)

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -71,55 +71,33 @@ TEST(TestGameClientDiscModel, MultipleRemovedSlotsCanCoexist)
   EXPECT_TRUE(model.IsRemovedSlotByIndex(2));
 }
 
-TEST(TestGameClientDiscModel, ReplacementSkipsRemovedSlots)
+TEST(TestGameClientDiscModel, SelectionReplacementSkipsRemovedSlots)
 {
-  // Verify selected/last replacement skips removed tombstones.
+  // Verify selected replacement skips removed tombstones.
   CGameClientDiscModel model;
 
   ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
   ASSERT_TRUE(model.AddDisc("/roms/disc2.chd"));
   ASSERT_TRUE(model.AddDisc("/roms/disc3.chd"));
 
-  ASSERT_TRUE(model.SetLastDiscByIndex(1));
   ASSERT_TRUE(model.SetSelectedDiscByIndex(1));
   ASSERT_TRUE(model.MarkRemovedByIndex(1));
 
   ASSERT_TRUE(model.GetSelectedDiscIndex().has_value());
   EXPECT_EQ(*model.GetSelectedDiscIndex(), 0U);
-  EXPECT_EQ(model.GetLastDiscPath(), "/roms/disc1.chd");
 }
 
-TEST(TestGameClientDiscModel, SelectionAndLastDoNotPointToRemoved)
-{
-  // Verify tracked indices are redirected away from removed slots.
-  CGameClientDiscModel model;
-
-  ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
-  ASSERT_TRUE(model.AddDisc("/roms/disc2.chd"));
-  ASSERT_TRUE(model.SetLastDiscByIndex(1));
-  ASSERT_TRUE(model.SetSelectedDiscByIndex(1));
-
-  ASSERT_TRUE(model.MarkRemovedByIndex(1));
-
-  ASSERT_TRUE(model.GetSelectedDiscIndex().has_value());
-  EXPECT_EQ(*model.GetSelectedDiscIndex(), 0U);
-  EXPECT_EQ(model.GetLastDiscPath(), "/roms/disc1.chd");
-}
-
-
-TEST(TestGameClientDiscModel, RemovingOnlySelectedDiscClearsSelectionAndLast)
+TEST(TestGameClientDiscModel, RemovingOnlySelectedDiscClearsSelection)
 {
   CGameClientDiscModel model;
 
   ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
-  ASSERT_TRUE(model.SetLastDiscByIndex(0));
   ASSERT_TRUE(model.SetSelectedDiscByIndex(0));
 
   ASSERT_TRUE(model.MarkRemovedByIndex(0));
 
   EXPECT_TRUE(model.IsSelectedNoDisc());
   EXPECT_FALSE(model.GetSelectedDiscIndex().has_value());
-  EXPECT_EQ(model.GetLastDiscPath(), "");
 }
 
 TEST(TestGameClientDiscModel, MixedSlotModelBehavior)
@@ -206,8 +184,6 @@ TEST(TestGameClientDiscModel, MergeSelectionMappingKeepsDiscIndex)
 
   const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
 
-  ASSERT_TRUE(merged.firstSelectable.has_value());
-  EXPECT_EQ(*merged.firstSelectable, 1U);
   ASSERT_EQ(merged.coreToMerged.size(), 2U);
   ASSERT_TRUE(merged.coreToMerged[0].has_value());
   EXPECT_EQ(*merged.coreToMerged[0], 0U);

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -89,23 +89,6 @@ TEST(TestGameClientDiscModel, ReplacementSkipsRemovedSlots)
   EXPECT_EQ(model.GetLastDiscPath(), "/roms/disc1.chd");
 }
 
-TEST(TestGameClientDiscModel, EmptyAndRemovedSlotsRemainDistinct)
-{
-  // Verify zombie empty slots are distinct from frontend removed slots.
-  CGameClientDiscModel model;
-
-  ASSERT_TRUE(model.AddEmptySlot("Zombie Slot"));
-  ASSERT_TRUE(model.AddDisc("/roms/disc2.chd"));
-  ASSERT_TRUE(model.MarkRemovedByIndex(1));
-
-  EXPECT_TRUE(model.IsEmptySlotByIndex(0));
-  EXPECT_FALSE(model.IsRemovedSlotByIndex(0));
-  EXPECT_TRUE(model.IsRemovedSlotByIndex(1));
-  EXPECT_FALSE(model.IsEmptySlotByIndex(1));
-  EXPECT_EQ(model.GetLabelByIndex(0), "Zombie Slot");
-  EXPECT_EQ(model.GetLabelByIndex(1), "");
-}
-
 TEST(TestGameClientDiscModel, SelectionMainAndLastDoNotPointToRemoved)
 {
   // Verify tracked indices are redirected away from removed slots.
@@ -127,30 +110,42 @@ TEST(TestGameClientDiscModel, SelectionMainAndLastDoNotPointToRemoved)
 
 TEST(TestGameClientDiscModel, MixedSlotModelBehavior)
 {
-  // Verify mixed Disc/EmptySlot/RemovedSlot behavior for labels and paths.
+  // Verify mixed Disc/RemovedSlot behavior for labels and paths.
   CGameClientDiscModel model;
 
   ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
-  ASSERT_TRUE(model.AddEmptySlot("Core Empty"));
+  ASSERT_TRUE(model.AddRemovedSlot());
   ASSERT_TRUE(model.AddDisc("/roms/disc3.chd", "Disc 3"));
   ASSERT_TRUE(model.MarkRemovedByIndex(2));
 
   EXPECT_EQ(model.GetPathByIndex(0), "/roms/disc1.chd");
   EXPECT_EQ(model.GetLabelByIndex(0), "disc1.chd");
   EXPECT_EQ(model.GetPathByIndex(1), "");
-  EXPECT_EQ(model.GetLabelByIndex(1), "Core Empty");
+  EXPECT_EQ(model.GetLabelByIndex(1), "");
   EXPECT_EQ(model.GetPathByIndex(2), "");
   EXPECT_EQ(model.GetLabelByIndex(2), "");
 }
 
-TEST(TestGameClientDiscModel, MergePreservesRemovedTombstoneWhenCoreReportsEmpty)
+
+TEST(TestGameClientDiscModel, RemovedSlotsAreNotSelectable)
+{
+  CGameClientDiscModel model;
+
+  ASSERT_TRUE(model.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(model.AddRemovedSlot());
+
+  EXPECT_TRUE(model.IsSelectableSlotByIndex(0));
+  EXPECT_FALSE(model.IsSelectableSlotByIndex(1));
+}
+
+TEST(TestGameClientDiscModel, MergePreservesRemovedTombstoneWhenCoreReportsRemoved)
 {
   std::vector<GameClientDiscEntry> previousDiscs{
       {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
       {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
 
   std::vector<GameClientDiscEntry> coreDiscs{
-      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Zombie"},
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
       {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
 
   const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
@@ -160,22 +155,6 @@ TEST(TestGameClientDiscModel, MergePreservesRemovedTombstoneWhenCoreReportsEmpty
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
 }
 
-TEST(TestGameClientDiscModel, MergePreservesGenuineEmptySlotWhenNoRemovedTombstone)
-{
-  std::vector<GameClientDiscEntry> previousDiscs{
-      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc1.chd", "disc1.chd", ""}};
-
-  std::vector<GameClientDiscEntry> coreDiscs{
-      {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc1.chd", "disc1.chd", ""},
-      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Core Empty"}};
-
-  const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
-
-  ASSERT_EQ(merged.discs.size(), 2U);
-  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::EmptySlot);
-  EXPECT_EQ(merged.discs[1].cachedLabel, "Core Empty");
-}
-
 TEST(TestGameClientDiscModel, MergeDoesNotDuplicateRemovedTombstone)
 {
   std::vector<GameClientDiscEntry> previousDiscs{
@@ -183,38 +162,33 @@ TEST(TestGameClientDiscModel, MergeDoesNotDuplicateRemovedTombstone)
       {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
 
   std::vector<GameClientDiscEntry> coreDiscs{
-      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Zombie"},
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
       {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
 
   const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
 
   size_t removedCount = 0;
   size_t discCount = 0;
-  size_t emptyCount = 0;
-
   for (const auto& disc : merged.discs)
   {
     if (disc.slotType == GameClientDiscEntry::DiscSlotType::RemovedSlot)
       ++removedCount;
     else if (disc.slotType == GameClientDiscEntry::DiscSlotType::Disc)
       ++discCount;
-    else
-      ++emptyCount;
   }
 
   EXPECT_EQ(removedCount, 1U);
   EXPECT_EQ(discCount, 1U);
-  EXPECT_EQ(emptyCount, 0U);
 }
 
-TEST(TestGameClientDiscModel, MergeSelectionMappingSkipsRemovedSlot)
+TEST(TestGameClientDiscModel, MergeSelectionMappingKeepsDiscIndex)
 {
   std::vector<GameClientDiscEntry> previousDiscs{
       {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
       {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
 
   std::vector<GameClientDiscEntry> coreDiscs{
-      {GameClientDiscEntry::DiscSlotType::EmptySlot, "", "", "Zombie"},
+      {GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""},
       {GameClientDiscEntry::DiscSlotType::Disc, "/roms/disc2.chd", "disc2.chd", ""}};
 
   const MergedDiscSlots merged = MergeCoreSlotsByIndex(previousDiscs, coreDiscs);
@@ -222,7 +196,8 @@ TEST(TestGameClientDiscModel, MergeSelectionMappingSkipsRemovedSlot)
   ASSERT_TRUE(merged.firstSelectable.has_value());
   EXPECT_EQ(*merged.firstSelectable, 1U);
   ASSERT_EQ(merged.coreToMerged.size(), 2U);
-  EXPECT_FALSE(merged.coreToMerged[0].has_value());
+  ASSERT_TRUE(merged.coreToMerged[0].has_value());
+  EXPECT_EQ(*merged.coreToMerged[0], 0U);
   ASSERT_TRUE(merged.coreToMerged[1].has_value());
   EXPECT_EQ(*merged.coreToMerged[1], 1U);
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -244,3 +244,15 @@ TEST(TestGameClientDiscModel, MergePreservesTrailingRemovedSlotsWhenCoreShrinks)
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
   EXPECT_EQ(merged.discs[2].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
 }
+
+TEST(TestGameClientDiscModel, ClearResetsEjectedState)
+{
+  CGameClientDiscModel model;
+
+  model.SetEjected(true);
+  ASSERT_TRUE(model.IsEjected());
+
+  model.Clear();
+
+  EXPECT_FALSE(model.IsEjected());
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -126,7 +126,6 @@ TEST(TestGameClientDiscModel, MixedSlotModelBehavior)
   EXPECT_EQ(model.GetLabelByIndex(2), "");
 }
 
-
 TEST(TestGameClientDiscModel, RemovedSlotsAreNotSelectable)
 {
   CGameClientDiscModel model;

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -43,13 +43,13 @@ std::string ReadStateXml()
 }
 } // namespace
 
-TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypesAndLabels)
+TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypes)
 {
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
   ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd", "Disc One"));
-  ASSERT_TRUE(savedModel.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(savedModel.AddRemovedSlot());
   ASSERT_TRUE(savedModel.AddRemovedSlot());
 
   ASSERT_TRUE(savedModel.SetSelectedDiscByIndex(0));
@@ -62,11 +62,10 @@ TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypesAndLabels)
 
   ASSERT_EQ(loadedModel.Size(), 3U);
   EXPECT_TRUE(loadedModel.IsRealDiscByIndex(0));
-  EXPECT_TRUE(loadedModel.IsEmptySlotByIndex(1));
+  EXPECT_TRUE(loadedModel.IsRemovedSlotByIndex(1));
   EXPECT_TRUE(loadedModel.IsRemovedSlotByIndex(2));
   EXPECT_EQ(loadedModel.GetPathByIndex(0), "/roms/disc1.chd");
   EXPECT_EQ(loadedModel.GetLabelByIndex(0), "Disc One");
-  EXPECT_EQ(loadedModel.GetLabelByIndex(1), "Zombie");
 
   ASSERT_TRUE(loadedModel.GetSelectedDiscIndex().has_value());
   EXPECT_EQ(*loadedModel.GetSelectedDiscIndex(), 0U);
@@ -127,14 +126,14 @@ TEST(TestGameClientDiscXML, MalformedXmlFailsAndClearsModel)
   CleanupStateFile();
 }
 
-TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreEmpty)
+TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreRemoved)
 {
   CGameClientDiscModel loadedModel;
   ASSERT_TRUE(loadedModel.AddRemovedSlot());
   ASSERT_TRUE(loadedModel.AddDisc("/roms/disc2.chd"));
 
   CGameClientDiscModel coreModel;
-  ASSERT_TRUE(coreModel.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(coreModel.AddRemovedSlot());
   ASSERT_TRUE(coreModel.AddDisc("/roms/disc2.chd"));
 
   const MergedDiscSlots merged =
@@ -143,6 +142,32 @@ TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreEm
   ASSERT_EQ(merged.discs.size(), 2U);
   EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+}
+
+
+TEST(TestGameClientDiscXML, LoadLegacyEmptyTypeMapsToRemovedSlot)
+{
+  CleanupStateFile();
+
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
+
+  XFILE::CFile file;
+  ASSERT_TRUE(file.OpenForWrite(xmlPath, true));
+  static constexpr char xml[] =
+      "<discstate><slots><slot type=\"empty\" label=\"Zombie\"/></slots></discstate>";
+  ASSERT_EQ(file.Write(xml, sizeof(xml) - 1), sizeof(xml) - 1);
+  file.Close();
+
+  CGameClientDiscXML discXml;
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+
+  ASSERT_EQ(loadedModel.Size(), 1U);
+  EXPECT_TRUE(loadedModel.IsRemovedSlotByIndex(0));
+  EXPECT_EQ(loadedModel.GetPathByIndex(0), "");
+  EXPECT_EQ(loadedModel.GetLabelByIndex(0), "");
+
+  CleanupStateFile();
 }
 
 TEST(TestGameClientDiscXML, SaveWritesEjectedTrue)

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -24,6 +24,23 @@ void CleanupStateFile()
 {
   XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(GAME_PATH));
 }
+
+std::string ReadStateXml()
+{
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
+
+  XFILE::CFile file;
+  if (!file.Open(xmlPath))
+    return "";
+
+  std::string xml;
+  xml.resize(static_cast<size_t>(file.GetLength()));
+  if (!xml.empty())
+    file.Read(xml.data(), xml.size());
+
+  file.Close();
+  return xml;
+}
 } // namespace
 
 TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypesAndLabels)
@@ -126,4 +143,96 @@ TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreEm
   ASSERT_EQ(merged.discs.size(), 2U);
   EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+}
+
+TEST(TestGameClientDiscXML, SaveWritesEjectedTrue)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(true);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  const std::string xml = ReadStateXml();
+  EXPECT_NE(xml.find("<tray ejected=\"true\""), std::string::npos);
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, SaveWritesEjectedFalse)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(false);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  const std::string xml = ReadStateXml();
+  EXPECT_NE(xml.find("<tray ejected=\"false\""), std::string::npos);
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, LoadRestoresEjectedState)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(true);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+  EXPECT_TRUE(loadedModel.IsEjected());
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, LoadRestoresEjectedFalseState)
+{
+  CleanupStateFile();
+
+  CGameClientDiscModel savedModel;
+  ASSERT_TRUE(savedModel.AddDisc("/roms/disc1.chd"));
+  savedModel.SetEjected(false);
+
+  CGameClientDiscXML discXml;
+  ASSERT_TRUE(discXml.Save(GAME_PATH, savedModel));
+
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+  EXPECT_FALSE(loadedModel.IsEjected());
+
+  CleanupStateFile();
+}
+
+TEST(TestGameClientDiscXML, LoadMissingEjectedDefaultsToFalse)
+{
+  CleanupStateFile();
+
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
+
+  XFILE::CFile file;
+  ASSERT_TRUE(file.OpenForWrite(xmlPath, true));
+  static constexpr char xml[] =
+      "<discstate><slots><slot type=\"disc\" path=\"/roms/disc1.chd\"/></slots></discstate>";
+  ASSERT_EQ(file.Write(xml, sizeof(xml) - 1), sizeof(xml) - 1);
+  file.Close();
+
+  CGameClientDiscXML discXml;
+  CGameClientDiscModel loadedModel;
+  ASSERT_TRUE(discXml.Load(GAME_PATH, loadedModel));
+
+  EXPECT_FALSE(loadedModel.IsEjected());
+
+  CleanupStateFile();
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -144,7 +144,6 @@ TEST(TestGameClientDiscXML, MergeAfterLoadPreservesRemovedTombstoneAgainstCoreRe
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
 }
 
-
 TEST(TestGameClientDiscXML, LoadLegacyEmptyTypeMapsToRemovedSlot)
 {
   CleanupStateFile();

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "games/addons/disc/GameClientDiscMergeUtils.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscs.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+TEST(TestGameClientDiscs, PersistedModelSurvivesEmptyCoreMerge)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  CGameClientDiscModel core;
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[0].path, "/roms/disc1.chd");
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  EXPECT_EQ(merged.discs[1].path, "/roms/disc2.chd");
+}
+
+TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+
+  ASSERT_TRUE(HasUsableStartupDisc(persisted, selectedIndex, startupPath));
+  ASSERT_TRUE(selectedIndex.has_value());
+  EXPECT_EQ(*selectedIndex, 1U);
+  EXPECT_EQ(startupPath, "/roms/disc2.chd");
+}
+
+TEST(TestGameClientDiscs, EmptyPersistedAndEmptyCoreRemainEmpty)
+{
+  CGameClientDiscModel persisted;
+  CGameClientDiscModel core;
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  EXPECT_TRUE(merged.discs.empty());
+  EXPECT_FALSE(merged.firstSelectable.has_value());
+}
+
+TEST(TestGameClientDiscs, PersistedAndCoreNonEmptyStillMerge)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddRemovedSlot());
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
+
+  CGameClientDiscModel core;
+  ASSERT_TRUE(core.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(core.AddDisc("/roms/disc2.chd"));
+
+  const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
+
+  ASSERT_EQ(merged.discs.size(), 2U);
+  EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
+  EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
+  ASSERT_TRUE(merged.firstSelectable.has_value());
+  EXPECT_EQ(*merged.firstSelectable, 1U);
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -70,7 +70,6 @@ TEST(TestGameClientDiscs, EmptyPersistedAndEmptyCoreRemainEmpty)
   const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());
 
   EXPECT_TRUE(merged.discs.empty());
-  EXPECT_FALSE(merged.firstSelectable.has_value());
 }
 
 TEST(TestGameClientDiscs, PersistedAndCoreNonEmptyStillMerge)
@@ -88,6 +87,4 @@ TEST(TestGameClientDiscs, PersistedAndCoreNonEmptyStillMerge)
   ASSERT_EQ(merged.discs.size(), 2U);
   EXPECT_EQ(merged.discs[0].slotType, GameClientDiscEntry::DiscSlotType::RemovedSlot);
   EXPECT_EQ(merged.discs[1].slotType, GameClientDiscEntry::DiscSlotType::Disc);
-  ASSERT_TRUE(merged.firstSelectable.has_value());
-  EXPECT_EQ(*merged.firstSelectable, 1U);
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -49,6 +49,20 @@ TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
   EXPECT_EQ(startupPath, "/roms/disc2.chd");
 }
 
+
+TEST(TestGameClientDiscs, HasUsableStartupDiscRejectsNonDiscSelection)
+{
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(persisted.AddDisc("/roms/disc1.chd"));
+  ASSERT_TRUE(persisted.AddRemovedSlot());
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+
+  std::optional<size_t> selectedIndex;
+  std::string startupPath;
+
+  EXPECT_FALSE(HasUsableStartupDisc(persisted, selectedIndex, startupPath));
+}
+
 TEST(TestGameClientDiscs, EmptyPersistedAndEmptyCoreRemainEmpty)
 {
   CGameClientDiscModel persisted;

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -49,7 +49,6 @@ TEST(TestGameClientDiscs, HasUsableStartupDiscUsesPersistedSelectedDisc)
   EXPECT_EQ(startupPath, "/roms/disc2.chd");
 }
 
-
 TEST(TestGameClientDiscs, HasUsableStartupDiscRejectsNonDiscSelection)
 {
   CGameClientDiscModel persisted;

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -80,7 +80,7 @@ TEST(TestGameClientDiscs, PersistedAndCoreNonEmptyStillMerge)
   ASSERT_TRUE(persisted.AddDisc("/roms/disc2.chd"));
 
   CGameClientDiscModel core;
-  ASSERT_TRUE(core.AddEmptySlot("Zombie"));
+  ASSERT_TRUE(core.AddRemovedSlot());
   ASSERT_TRUE(core.AddDisc("/roms/disc2.chd"));
 
   const MergedDiscSlots merged = MergeCoreSlotsByIndex(persisted.GetDiscs(), core.GetDiscs());


### PR DESCRIPTION
### Motivation
- The disc model kept a redundant “last disc” bookkeeping state that adds complexity to repair/merge logic and persistence assumptions. 
- The goal is to remove all traces of `last disc` while preserving selected/no-disc behavior, removed tombstones, ejected state persistence, and UI compatibility.

### Description
- Remove the `m_lastDiscIndex` member and the APIs `SetLastDiscByPath()`, `SetLastDiscByIndex()` and `GetLastDiscPath()`, and update model invariants/comments to only refer to selected-disc state (`CGameClientDiscModel`).
- Update disc model methods (`Clear()`, `SetDiscs()`, `AddDisc()`, `MarkRemovedByIndex()`) to stop initializing/repairing last-disc state and to keep selected-disc repair logic intact.
- Stop assigning last-disc during core model build (`BuildModelFromCore`) and frontend merge (`MergeCoreModelIntoFrontend`) and remove the fallback plumbing (`firstSelectable` / `IsSelectableDiscSlot`) used only for last-disc handling (`GameClientDiscs`, `GameClientDiscMergeUtils`).
- Remove load-time last-disc initialization from XML handling and keep XML persistence focused on slots, selected/no-disc and tray ejected state (`GameClientDiscXML`).
- Update tests to remove last-disc assertions and retain coverage for selected-disc repair, removed tombstones, merge mapping and ejected/selected persistence changes (`test/*`).

### Testing
- Ran a repository search to confirm removal: `rg -n "SetLastDiscBy|GetLastDiscPath|m_lastDiscIndex|firstSelectable|IsSelectableDiscSlot" xbmc/games/addons/disc xbmc/games/addons/disc/test` and verified no remaining references to removed APIs/fields.
- Ran `git diff --check` and committed the changes as `games: remove last-disc tracking from disc model` (commit `df2266cce`), with no whitespace/diff-check errors.
- Attempted project configure to build tests via `cmake -S . -B build -G Ninja -DENABLE_TESTING=ON` and with `-DAPP_RENDER_SYSTEM=gl -DENABLE_UDEV=OFF`, but configuration failed in this environment due to platform/UDEV requirements so a full build/test run was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b04b70b1f4832e8cb60023b830fb36)